### PR TITLE
Refactor gallery: shared MediaElement, Android file split

### DIFF
--- a/Projects/TravelCam/.claude/settings.local.json
+++ b/Projects/TravelCam/.claude/settings.local.json
@@ -25,7 +25,13 @@
       "Bash(taskkill /F /IM mono.exe /IM dotnet.exe)",
       "Bash(git:*)",
       "WebSearch",
-      "Bash(taskkill /F /IM \"Microsoft.VisualStudio.exe\")"
+      "Bash(taskkill /F /IM \"Microsoft.VisualStudio.exe\")",
+      "Read(//tmp/**)",
+      "WebFetch(domain:www.nuget.org)",
+      "Bash(dotnet restore:*)",
+      "Bash(powershell:*)",
+      "Bash(ls \"C:/Users/yoyok/Git/Playground/Projects/TravelCam/\"*.bak)",
+      "Bash(ls \"C:/Users/yoyok/Git/Playground/Projects/TravelCam/TravelCamApp/Helpers/\"*.bak)"
     ]
   },
   "ENABLE_TOOL_SEARCH": "true"

--- a/Projects/TravelCam/CLAUDE.md
+++ b/Projects/TravelCam/CLAUDE.md
@@ -5,6 +5,27 @@
 
 ---
 
+## REQUIRED SKILLS — Load Before Every Task
+
+The following skills from `~/.claude/commands/` apply to this project. Always consult them before writing or modifying code.
+
+| Skill | When to use |
+|---|---|
+| `/maui-current-apis` | **Always first** — deprecated API guardrail |
+| `/maui-app-lifecycle` | Any camera/sensor lifecycle, Window events, ANR prevention |
+| `/maui-data-binding` | Any XAML binding, `x:DataType`, `ObservableCollection` |
+| `/maui-collectionview` | Gallery thumbnail strip, any `CollectionView` changes |
+| `/maui-permissions` | Camera, mic, location, storage permission flows |
+| `/maui-geolocation` | GPS calls — always pass `CancellationToken` |
+| `/maui-file-handling` | MediaStore, file paths, `content://` URIs |
+| `/maui-platform-invoke` | `#if ANDROID`, partial classes, `Platform.CurrentActivity` |
+| `/maui-performance` | Compiled bindings, layout nesting, image sizing |
+| `/maui-safe-area` | `.NET 10` edge-to-edge, `SafeAreaEdges` |
+| `/maui-dependency-injection` | DI lifetimes, singleton vs transient, registration |
+| `/maui-gestures` | Tap/swipe/pan recognizers, `.NET 10` deprecations |
+
+---
+
 ## PROJECT OVERVIEW
 
 TravelCam is a .NET MAUI camera application for Android (API 29+) that captures photos and video with real-time sensor data overlays (location, temperature, compass). It follows MVVM architecture with dependency injection.
@@ -13,12 +34,13 @@ TravelCam is a .NET MAUI camera application for Android (API 29+) that captures 
 
 | Component | Version |
 |---|---|
-| .NET MAUI | 10.0.30 |
+| .NET MAUI | 10.0.41 |
 | Target Framework | `net10.0-android` (also `net10.0-windows10.0.19041.0`) |
 | Android Min SDK | API 29 (Android 10) |
-| Android Target SDK | API 35 (Android 15) |
-| CommunityToolkit.Maui | 14.0.0 |
-| CommunityToolkit.Maui.Camera | 6.0.0 |
+| Android Target SDK | API 36 (Android 16) |
+| CommunityToolkit.Maui | 14.1.0 |
+| CommunityToolkit.Maui.Camera | 6.0.1 |
+| CommunityToolkit.Maui.MediaElement | 8.0.1 |
 
 ### Source
 
@@ -130,19 +152,20 @@ string FailureReason { get; }
 
 ### Dependency Injection (MauiProgram.cs)
 ```csharp
-// Singletons — shared across app
+// Singletons — shared across app lifetime
 builder.Services.AddSingleton<SensorHelper>();
+builder.Services.AddSingleton<CameraSettingsViewModel>();
+builder.Services.AddSingleton<DataOverlayViewModel>();
 
 // Transient — new instance per injection
-builder.Services.AddTransient<DataOverlayViewModel>();
 builder.Services.AddTransient<OverlaySettingsViewModel>();
 builder.Services.AddTransient<MainPageViewModel>();
 builder.Services.AddTransient<MainPage>();
 ```
 
 ### Camera Lifecycle
-1. `CamerasLoaded` event fires → ViewModel receives CameraView reference
-2. ViewModel calls `CameraHelper.SelectFirstAvailableCamera()` then `StartPreviewAsync()`
+1. `OnAppearing()` → `await ViewModel.OnViewReady(CameraView)` initializes camera
+2. ViewModel calls `CameraHelper.SelectFirstAvailableCamera()` then `StartCameraPreview()`
 3. `Window.Stopped` → stop camera, stop sensors
 4. `Window.Resumed` → restart sensors, restart camera preview
 
@@ -285,7 +308,7 @@ public List<string> GalleryImagePaths { get; set; } = new();
 
 When asked to build or fix, run:
 ```bash
-cd C:\Git\Playground\Projects\TravelCam\TravelCamApp
+cd C:\Users\yoyok\Git\Playground\Projects\TravelCam\TravelCamApp
 dotnet build -f net10.0-android
 ```
 

--- a/Projects/TravelCam/MEMORY.md
+++ b/Projects/TravelCam/MEMORY.md
@@ -182,8 +182,11 @@ class MediaCaptureFailedEventArgs {
 ```csharp
 // SavePhotoAsync returns a TUPLE — not just a string
 Task<(string GalleryPath, string ThumbPath)> SavePhotoAsync(Stream, string city)
+// SaveVideoAsync saves video and returns (GalleryPath, ThumbPath) where ThumbPath is first frame
+Task<(string GalleryPath, string ThumbPath)> SaveVideoAsync(Stream, string city)
 // Usage:
 var (galleryPath, thumbPath) = await FileHelper.SavePhotoAsync(stream, city);
+var (videoGalleryPath, videoThumbPath) = await FileHelper.SaveVideoAsync(videoStream, city);
 ```
 
 ---

--- a/Projects/TravelCam/TravelCamApp/App.xaml.cs
+++ b/Projects/TravelCam/TravelCamApp/App.xaml.cs
@@ -7,11 +7,36 @@ namespace TravelCamApp
         public App()
         {
             InitializeComponent();
+
+            // Global crash diagnostics — logs to debug output so logcat shows the root cause
+            AppDomain.CurrentDomain.UnhandledException += (s, e) =>
+            {
+                var ex = e.ExceptionObject as Exception;
+                System.Diagnostics.Debug.WriteLine(
+                    $"[FATAL] UnhandledException: {ex?.GetType().Name} — {ex?.Message}\n{ex?.StackTrace}");
+            };
+
+            TaskScheduler.UnobservedTaskException += (s, e) =>
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[FATAL] UnobservedTaskException: {e.Exception.GetType().Name} — {e.Exception.Message}\n{e.Exception.StackTrace}");
+                e.SetObserved(); // prevent process kill so we can see the log
+            };
         }
 
         protected override Window CreateWindow(IActivationState? activationState)
         {
-            return new Window(new AppShell());
+            try
+            {
+                System.Diagnostics.Debug.WriteLine("[App] CreateWindow called");
+                return new Window(new AppShell());
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[FATAL] CreateWindow failed: {ex.GetType().Name} — {ex.Message}\n{ex.StackTrace}");
+                throw;
+            }
         }
     }
 }

--- a/Projects/TravelCam/TravelCamApp/Helpers/FileHelper.cs
+++ b/Projects/TravelCam/TravelCamApp/Helpers/FileHelper.cs
@@ -1,6 +1,6 @@
 // ========================================== //
 // Developer: Yohanes Wahyu Nurcahyo          //
-// Website: https://github.com/yoyokits       //
+// Website: https://github.com/yoyokitos       //
 // ========================================== //
 
 using System;
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace TravelCamApp.Helpers
 {
-    public static class FileHelper
+    public static partial class FileHelper
     {
         #region Fields / Constants
 
@@ -40,7 +40,6 @@ namespace TravelCamApp.Helpers
 
             System.Diagnostics.Debug.WriteLine($"[FileHelper] SaveVideoAsync called: city={city}, stream.Length={stream.Length}, CanSeek={stream.CanSeek}");
 
-            // Guard against empty streams
             if (stream.Length == 0)
             {
                 System.Diagnostics.Debug.WriteLine("[FileHelper] SaveVideoAsync: Stream is empty — aborting.");
@@ -75,7 +74,7 @@ namespace TravelCamApp.Helpers
                 return (null, null);
             }
 
-            // Extract first frame as thumbnail before publishing to MediaStore
+            // Extract first frame as thumbnail before publishing to MediaStore (Android only)
             var thumbPath = string.Empty;
 #if ANDROID
             var thumbFileName = Path.GetFileNameWithoutExtension(tempPath) + "_thumb.jpg";
@@ -90,114 +89,6 @@ namespace TravelCamApp.Helpers
             return (galleryPath ?? tempPath, thumbPath);
         }
 
-#if ANDROID
-        /// <summary>
-        /// Extracts the first frame of a video file and saves it as a JPEG thumbnail.
-        /// Returns the thumb file path, or empty string on failure.
-        /// </summary>
-        private static string ExtractVideoFirstFrame(string videoPath, string outputThumbPath)
-        {
-            Android.Graphics.Bitmap? bitmap = null;
-            try
-            {
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] ExtractVideoFirstFrame START: video='{videoPath}', thumb='{outputThumbPath}'");
-
-                if (!File.Exists(videoPath))
-                {
-                    System.Diagnostics.Debug.WriteLine("[FileHelper] ERROR: Video file does not exist!");
-                    return string.Empty;
-                }
-
-                var videoSize = new FileInfo(videoPath).Length;
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] Video file size: {videoSize} bytes");
-                if (videoSize == 0)
-                {
-                    System.Diagnostics.Debug.WriteLine("[FileHelper] ERROR: Video file is empty!");
-                    return string.Empty;
-                }
-
-                System.Diagnostics.Debug.WriteLine("[FileHelper] Creating MediaMetadataRetriever...");
-                using var retriever = new Android.Media.MediaMetadataRetriever();
-                System.Diagnostics.Debug.WriteLine("[FileHelper] Setting data source...");
-                retriever.SetDataSource(videoPath);
-                System.Diagnostics.Debug.WriteLine("[FileHelper] Attempting to get frame with ClosestSync...");
-                bitmap = retriever.GetFrameAtTime(0, Android.Media.Option.ClosestSync);
-                if (bitmap == null)
-                {
-                    System.Diagnostics.Debug.WriteLine("[FileHelper] ClosestSync returned null, trying Closest...");
-                    // Try again with Option.Closest (any frame)
-                    bitmap = retriever.GetFrameAtTime(0, Android.Media.Option.Closest);
-                    if (bitmap == null)
-                    {
-                        System.Diagnostics.Debug.WriteLine("[FileHelper] Closest also returned null! Video may have no video track or unsupported codec.");
-                        return string.Empty;
-                    }
-                }
-
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] Got bitmap: {bitmap.Width}x{bitmap.Height}");
-
-                var thumbPath = outputThumbPath;
-                var thumbDir = Path.GetDirectoryName(thumbPath);
-                if (!string.IsNullOrEmpty(thumbDir))
-                    Directory.CreateDirectory(thumbDir);
-
-                // Scale down the bitmap to a reasonable thumbnail size (e.g., 120x120) to reduce memory and file size
-                const int maxDim = 120;
-                Android.Graphics.Bitmap scaledBitmap;
-                if (bitmap.Width > maxDim || bitmap.Height > maxDim)
-                {
-                    float scale = Math.Min((float)maxDim / bitmap.Width, (float)maxDim / bitmap.Height);
-                    int newWidth = (int)(bitmap.Width * scale);
-                    int newHeight = (int)(bitmap.Height * scale);
-                    scaledBitmap = Android.Graphics.Bitmap.CreateScaledBitmap(bitmap, newWidth, newHeight, true);
-                    if (scaledBitmap != bitmap)
-                        bitmap.Recycle(); // free original if scaled
-                }
-                else
-                {
-                    scaledBitmap = bitmap;
-                }
-
-                using var outStream = new FileStream(thumbPath, FileMode.Create, FileAccess.Write, FileShare.None);
-                bool compressed = scaledBitmap.Compress(Android.Graphics.Bitmap.CompressFormat.Jpeg!, 85, outStream);
-                outStream.Flush();
-                if (scaledBitmap != bitmap)
-                    scaledBitmap.Recycle();
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] Video thumbnail saved: {thumbPath} (scaled to {scaledBitmap.Width}x{scaledBitmap.Height}), compressed={compressed}");
-
-                // Verify the thumbnail file
-                if (File.Exists(thumbPath))
-                {
-                    var thumbSize = new FileInfo(thumbPath).Length;
-                    System.Diagnostics.Debug.WriteLine($"[FileHelper] Thumbnail file exists, size: {thumbSize} bytes");
-                    if (thumbSize == 0)
-                    {
-                        System.Diagnostics.Debug.WriteLine("[FileHelper] WARNING: Thumbnail file is empty!");
-                        try { File.Delete(thumbPath); } catch { }
-                        return string.Empty;
-                    }
-                }
-                else
-                {
-                    System.Diagnostics.Debug.WriteLine("[FileHelper] ERROR: Thumbnail file was not created!");
-                    return string.Empty;
-                }
-
-                return thumbPath;
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] ExtractVideoFirstFrame EXCEPTION: {ex.GetType().Name}: {ex.Message}");
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] StackTrace: {ex.StackTrace}");
-                return string.Empty;
-            }
-            finally
-            {
-                try { bitmap?.Dispose(); } catch { }
-            }
-        }
-#endif
-
         /// <summary>
         /// Saves a captured photo stream to the gallery and also keeps a private
         /// thumbnail copy in AppDataDirectory for the in-app preview.
@@ -211,7 +102,6 @@ namespace TravelCamApp.Helpers
             var timePart = now.ToString("HHmmss", CultureInfo.InvariantCulture);
             var safeCity = SanitizeFileName(city);
 
-            // Save to app-private cache first
             var baseDir = GetAppCacheDir();
             System.Diagnostics.Debug.WriteLine($"[FileHelper] SavePhotoAsync - Cache dir: {baseDir}");
 
@@ -226,13 +116,11 @@ namespace TravelCamApp.Helpers
             if (stream.CanSeek)
                 stream.Position = 0;
 
-            // Write to temp file and CLOSE it before CopyToGallery reads it.
             using (var fileStream = File.Open(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
             {
                 await stream.CopyToAsync(fileStream);
                 await fileStream.FlushAsync();
             }
-            // fileStream is now closed - safe to read from CopyToGallery.
 
             var fileInfo = new FileInfo(tempPath);
             System.Diagnostics.Debug.WriteLine($"[FileHelper] SavePhotoAsync - Temp file saved: {tempPath}, size: {fileInfo.Length} bytes");
@@ -244,7 +132,6 @@ namespace TravelCamApp.Helpers
             }
 
             // Save a private thumbnail copy BEFORE MediaStore deletes the temp file.
-            // Always use a plain file path (never content://) so it can be loaded via ImageSource.FromStream().
             var thumbPath = ThumbPath;
             try
             {
@@ -254,10 +141,9 @@ namespace TravelCamApp.Helpers
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"[FileHelper] Thumbnail copy failed: {ex.Message}");
-                thumbPath = tempPath; // fallback: keep using temp path
+                thumbPath = tempPath;
             }
 
-            // Copy into the gallery via MediaStore (Android 10+) or direct path (other platforms)
             System.Diagnostics.Debug.WriteLine($"[FileHelper] Calling CopyToGallery for {tempPath}");
             var galleryPath = CopyToGallery(tempPath, "image/jpeg");
             System.Diagnostics.Debug.WriteLine($"[FileHelper] CopyToGallery returned: {galleryPath}");
@@ -292,107 +178,24 @@ namespace TravelCamApp.Helpers
 
             System.Diagnostics.Debug.WriteLine($"[FileHelper] GetAllCapturedImagePaths - found {files.Count} files ({jpgFiles.Count} jpg, {mp4Files.Count} mp4)");
             foreach (var f in files)
-            {
                 System.Diagnostics.Debug.WriteLine($"  - {f} ({new FileInfo(f).Length} bytes)");
-            }
 
             return files;
         }
 
         /// <summary>
-        /// Queries MediaStore for all images and videos saved by TravelCam (in Pictures/CekliCam).
-        /// Returns file paths sorted newest first. Falls back to cache dir + thumb on failure.
+        /// Queries MediaStore for all images and videos saved by TravelCam.
+        /// Returns file paths sorted newest first. Falls back to cache dir on failure.
         /// </summary>
         public static List<string> GetAllGalleryMediaPaths()
         {
-            System.Diagnostics.Debug.WriteLine("[FileHelper] GetAllGalleryMediaPaths called");
-
 #if ANDROID
-            // First, try to get paths from MediaStore
-            try
-            {
-                var mediaStorePaths = GetMediaStoreImages();
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] MediaStore returned {mediaStorePaths.Count} paths");
-
-                // Filter to only existing files - MediaStore entries may be stale or inaccessible
-                var existingMediaPaths = mediaStorePaths
-                    .Where(p => !string.IsNullOrEmpty(p) && File.Exists(p))
-                    .ToList();
-
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] {existingMediaPaths.Count} MediaStore paths exist on disk");
-
-                // If we have valid MediaStore paths, return them
-                if (existingMediaPaths.Count > 0)
-                {
-                    // Also include cache files to ensure we always have images available
-                    var cachePaths = GetAllCapturedImagePaths();
-                    var allPaths = existingMediaPaths.Concat(cachePaths).Distinct()
-                        .OrderByDescending(p => File.GetLastWriteTime(p))
-                        .ToList();
-
-                    System.Diagnostics.Debug.WriteLine($"[FileHelper] Returning {allPaths.Count} combined paths");
-                    return allPaths.Count > 0 ? allPaths : GetAllCapturedImagePaths();
-                }
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine(
-                    $"[FileHelper] GetAllGalleryMediaPaths MediaStore error: {ex.Message}");
-            }
-
-            // MediaStore query returned empty or failed - fall back to cache files
-            // This handles: stale MediaStore entries, permission issues, app data cleared
-            System.Diagnostics.Debug.WriteLine("[FileHelper] Falling back to cache files");
-            return GetAllCapturedImagePaths();
+            return GetAllGalleryMediaPathsAndroid();
 #else
             System.Diagnostics.Debug.WriteLine("[FileHelper] Non-Android platform, returning cache files");
             return GetAllCapturedImagePaths();
 #endif
         }
-
-#if ANDROID
-        // Directly return captured images from the app's cache directory.
-        // This is simpler and more reliable than querying MediaStore.
-        private static List<string> GetMediaStoreImages()
-        {
-            return GetAllCapturedImagePaths();
-        }
-
-        private static void QueryMediaStore(
-            Android.Content.ContentResolver resolver,
-            Android.Net.Uri collection,
-            string relativePath,
-            List<(string path, long dateAdded)> results)
-        {
-            string[] projection = {
-                Android.Provider.MediaStore.IMediaColumns.Data!,
-                Android.Provider.MediaStore.IMediaColumns.DateAdded!
-            };
-
-            string selection = $"{Android.Provider.MediaStore.IMediaColumns.RelativePath} = ?";
-            string[] selectionArgs = { relativePath + "/" };
-
-            // Declare the resolver variable - it shadows the parameter due to nested #if scope
-            var contentResolver = resolver;
-
-            using var cursor = contentResolver.Query(collection, projection, selection, selectionArgs,
-                $"{Android.Provider.MediaStore.IMediaColumns.DateAdded} DESC");
-
-            if (cursor == null) return;
-
-            int dataIndex = cursor.GetColumnIndex(Android.Provider.MediaStore.IMediaColumns.Data!);
-            int dateIndex = cursor.GetColumnIndex(Android.Provider.MediaStore.IMediaColumns.DateAdded!);
-
-            while (cursor.MoveToNext())
-            {
-                var path = dataIndex >= 0 ? cursor.GetString(dataIndex) : null;
-                var dateAdded = dateIndex >= 0 ? cursor.GetLong(dateIndex) : 0;
-
-                if (!string.IsNullOrEmpty(path) && File.Exists(path))
-                    results.Add((path, dateAdded));
-            }
-        }
-#endif
 
         /// <summary>
         /// Deletes a media file from both the filesystem and MediaStore.
@@ -419,74 +222,13 @@ namespace TravelCamApp.Helpers
             }
         }
 
-#if ANDROID
-
-        // Static field to hold the ContentResolver reference
-        private static Android.Content.ContentResolver? _contentResolver;
-
-        /// <summary>
-        /// Gets the ContentResolver reference for use in ConvertMediaStorePathToFilePath.
-        /// </summary>
-        private static Android.Content.ContentResolver? Resolver => _contentResolver;
-
-        /// <summary>
-        /// Converts a MediaStore URI to an actual file path, or returns the path as-is if it's already a file path.
-        /// Returns empty string if conversion fails.
-        /// </summary>
-        // Simplified: just return path if it exists (caller validates)
-        private static string ConvertMediaStorePathToFilePath(string path)
-        {
-            if (!string.IsNullOrEmpty(path) && File.Exists(path))
-                return path;
-            return string.Empty;
-        }
-
-        /// <summary>
-        /// Initializes the resolver reference for use in ConvertMediaStorePathToFilePath.
-        /// This must be called before querying MediaStore images.
-        /// </summary>
-        public static void InitializeMediaStoreResolver(Android.Content.ContentResolver resolver)
-        {
-            _contentResolver = resolver;
-        }
-
-        private static void DeleteFromMediaStore(string filePath)
-        {
-            var context = Android.App.Application.Context;
-            var contentResolver = context.ContentResolver;
-            if (contentResolver == null) return;
-
-            // Try images collection first, then videos
-            var collections = new[] {
-                Android.Provider.MediaStore.Images.Media.ExternalContentUri!,
-                Android.Provider.MediaStore.Video.Media.ExternalContentUri!
-            };
-
-            foreach (var collection in collections)
-            {
-                string selection = $"{Android.Provider.MediaStore.IMediaColumns.Data} = ?";
-                string[] selectionArgs = { filePath };
-                int deleted = contentResolver.Delete(collection, selection, selectionArgs);
-                if (deleted > 0)
-                {
-                    System.Diagnostics.Debug.WriteLine($"[FileHelper] Removed from MediaStore: {filePath}");
-                    return;
-                }
-            }
-        }
-#endif
-
         /// <summary>
         /// Gets a temporary app-private directory for staging captures.
         /// </summary>
         private static string GetAppCacheDir()
         {
 #if ANDROID
-            var context = Android.App.Application.Context;
-            var cacheDir = context.ExternalCacheDir?.AbsolutePath
-                ?? context.CacheDir?.AbsolutePath
-                ?? FileSystem.CacheDirectory;
-            return Path.Combine(cacheDir, "captures");
+            return GetAppCacheDirAndroid();
 #else
             return Path.Combine(FileSystem.CacheDirectory, "captures");
 #endif
@@ -494,93 +236,17 @@ namespace TravelCamApp.Helpers
 
         /// <summary>
         /// Copies a file into shared gallery storage using MediaStore (Android 10+)
-        /// or direct file copy + media scan (older Android / other platforms).
+        /// or direct file copy + media scan (other platforms).
         /// Returns the gallery-visible path, or null on failure.
         /// </summary>
         private static string? CopyToGallery(string sourcePath, string mimeType)
         {
 #if ANDROID
-            try
-            {
-                var context = Android.App.Application.Context;
-                var fileName = Path.GetFileName(sourcePath);
-                return CopyToMediaStore(context, sourcePath, fileName, mimeType);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] CopyToGallery failed: {ex.Message}");
-                return null;
-            }
+            return CopyToGalleryAndroid(sourcePath, mimeType);
 #else
             return sourcePath;
 #endif
         }
-
-#if ANDROID
-        private static string? CopyToMediaStore(
-            Android.Content.Context context, string sourcePath, string fileName, string mimeType)
-        {
-            var isVideo = mimeType.StartsWith("video", StringComparison.OrdinalIgnoreCase);
-            var collection = isVideo
-                ? Android.Provider.MediaStore.Video.Media.ExternalContentUri
-                : Android.Provider.MediaStore.Images.Media.ExternalContentUri;
-
-            var values = new Android.Content.ContentValues();
-            values.Put(Android.Provider.MediaStore.IMediaColumns.DisplayName, Path.GetFileNameWithoutExtension(fileName));
-            values.Put(Android.Provider.MediaStore.IMediaColumns.MimeType, mimeType);
-            values.Put(Android.Provider.MediaStore.IMediaColumns.RelativePath,
-                $"{Android.OS.Environment.DirectoryPictures}/{Settings.DefaultCameraName}");
-            // Mark as pending so gallery apps don't show a blank entry during the write
-            values.Put(Android.Provider.MediaStore.IMediaColumns.IsPending, 1);
-
-            var resolver = context.ContentResolver;
-            var uri = resolver?.Insert(collection!, values);
-            if (uri == null || resolver == null)
-            {
-                System.Diagnostics.Debug.WriteLine("[FileHelper] MediaStore insert returned null URI");
-                return null;
-            }
-
-            try
-            {
-                using (var outputStream = resolver.OpenOutputStream(uri))
-                {
-                    if (outputStream == null)
-                    {
-                        resolver.Delete(uri, null, null);
-                        return null;
-                    }
-
-                    using var inputStream = File.OpenRead(sourcePath);
-                    inputStream.CopyTo(outputStream);
-                    outputStream.Flush();
-                }
-
-                // Clear pending flag - the file is now complete and gallery-visible
-                var updateValues = new Android.Content.ContentValues();
-                updateValues.Put(Android.Provider.MediaStore.IMediaColumns.IsPending, 0);
-                resolver.Update(uri, updateValues, null, null);
-
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] MediaStore: published {fileName} to gallery");
-
-                // NOTE: We do NOT delete sourcePath here because we need to return it
-                // for in-app viewing. The file remains in ExternalCacheDir and is
-                // accessible until the app is uninstalled or the cache is cleared.
-                // The MediaStore URI is NOT returned because Image control may not
-                // handle it correctly in all scenarios.
-
-                return sourcePath;
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"[FileHelper] MediaStore write failed: {ex.Message}");
-                // Remove the broken MediaStore entry
-                try { resolver.Delete(uri, null, null); } catch { }
-                return null;
-            }
-        }
-
-        #endif
 
         private static string SanitizeFileName(string name)
         {
@@ -607,7 +273,7 @@ namespace TravelCamApp.Helpers
                 if (!File.Exists(candidate))
                     return candidate;
             }
-            return filePath; // fallback (shouldn't reach here)
+            return filePath;
         }
 
         #endregion

--- a/Projects/TravelCam/TravelCamApp/MauiProgram.cs
+++ b/Projects/TravelCam/TravelCamApp/MauiProgram.cs
@@ -15,6 +15,7 @@ namespace TravelCamApp
                 .UseMauiApp<App>()
                 .UseMauiCommunityToolkit()
                 .UseMauiCommunityToolkitCamera()
+                .UseMauiCommunityToolkitMediaElement(isAndroidForegroundServiceEnabled: false)
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/Projects/TravelCam/TravelCamApp/Platforms/Android/CLAUDE.md
+++ b/Projects/TravelCam/TravelCamApp/Platforms/Android/CLAUDE.md
@@ -75,5 +75,5 @@ Used for: sharing captured photos with gallery apps via `FileProvider.GetUriForF
 
 ## Build Configuration
 
-`MainActivity.cs` — `LaunchMode = LaunchMode.SingleTop` to avoid multiple instances
+`MainActivity.cs` — `LaunchMode = LaunchMode.SingleTask`, `ResizeableActivity = true` (required for MediaElement)
 `MainApplication.cs` — Standard MAUI entry point, delegates to `MauiProgram.CreateMauiApp()`

--- a/Projects/TravelCam/TravelCamApp/Platforms/Android/FileHelper.cs
+++ b/Projects/TravelCam/TravelCamApp/Platforms/Android/FileHelper.cs
@@ -1,0 +1,270 @@
+// ========================================== //
+// Developer: Yohanes Wahyu Nurcahyo          //
+// Website: https://github.com/yoyokitos       //
+// ========================================== //
+//
+// Android-specific FileHelper implementations.
+// MSBuild automatically includes this file only for net10.0-android builds.
+
+using System;
+using System.IO;
+using System.Linq;
+using TravelCamApp.Helpers;
+
+namespace TravelCamApp.Helpers
+{
+    public static partial class FileHelper
+    {
+        private static Android.Content.ContentResolver? _contentResolver;
+
+        /// <summary>
+        /// Initializes the ContentResolver used for MediaStore operations.
+        /// Call this once from MainActivity or after camera initialization.
+        /// </summary>
+        public static void InitializeMediaStoreResolver(Android.Content.ContentResolver resolver)
+            => _contentResolver = resolver;
+
+        private static string GetAppCacheDirAndroid()
+        {
+            var context = Android.App.Application.Context;
+            var cacheDir = context.ExternalCacheDir?.AbsolutePath
+                ?? context.CacheDir?.AbsolutePath
+                ?? FileSystem.CacheDirectory;
+            return Path.Combine(cacheDir, "captures");
+        }
+
+        private static string? CopyToGalleryAndroid(string sourcePath, string mimeType)
+        {
+            try
+            {
+                var context = Android.App.Application.Context;
+                return CopyToMediaStore(context, sourcePath, Path.GetFileName(sourcePath), mimeType);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] CopyToGallery failed: {ex.Message}");
+                return null;
+            }
+        }
+
+        private static List<string> GetAllGalleryMediaPathsAndroid()
+        {
+            System.Diagnostics.Debug.WriteLine("[FileHelper] GetAllGalleryMediaPaths called");
+            try
+            {
+                var mediaStorePaths = GetMediaStoreImages();
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] MediaStore returned {mediaStorePaths.Count} paths");
+
+                var existingMediaPaths = mediaStorePaths
+                    .Where(p => !string.IsNullOrEmpty(p) && File.Exists(p))
+                    .ToList();
+
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] {existingMediaPaths.Count} MediaStore paths exist on disk");
+
+                if (existingMediaPaths.Count > 0)
+                {
+                    var cachePaths = GetAllCapturedImagePaths();
+                    var allPaths = existingMediaPaths.Concat(cachePaths).Distinct()
+                        .OrderByDescending(p => File.GetLastWriteTime(p))
+                        .ToList();
+
+                    System.Diagnostics.Debug.WriteLine($"[FileHelper] Returning {allPaths.Count} combined paths");
+                    return allPaths.Count > 0 ? allPaths : GetAllCapturedImagePaths();
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[FileHelper] GetAllGalleryMediaPaths MediaStore error: {ex.Message}");
+            }
+
+            System.Diagnostics.Debug.WriteLine("[FileHelper] Falling back to cache files");
+            return GetAllCapturedImagePaths();
+        }
+
+        // Currently returns cache files directly — MediaStore query kept as fallback for future use.
+        private static List<string> GetMediaStoreImages()
+            => GetAllCapturedImagePaths();
+
+        /// <summary>
+        /// Extracts the first frame of a video file and saves it as a JPEG thumbnail.
+        /// Returns the thumb file path, or empty string on failure.
+        /// </summary>
+        private static string ExtractVideoFirstFrame(string videoPath, string outputThumbPath)
+        {
+            Android.Graphics.Bitmap? bitmap = null;
+            try
+            {
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] ExtractVideoFirstFrame START: video='{videoPath}', thumb='{outputThumbPath}'");
+
+                if (!File.Exists(videoPath))
+                {
+                    System.Diagnostics.Debug.WriteLine("[FileHelper] ERROR: Video file does not exist!");
+                    return string.Empty;
+                }
+
+                var videoSize = new FileInfo(videoPath).Length;
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] Video file size: {videoSize} bytes");
+                if (videoSize == 0)
+                {
+                    System.Diagnostics.Debug.WriteLine("[FileHelper] ERROR: Video file is empty!");
+                    return string.Empty;
+                }
+
+                using var retriever = new Android.Media.MediaMetadataRetriever();
+                retriever.SetDataSource(videoPath);
+
+                bitmap = retriever.GetFrameAtTime(0, Android.Media.Option.ClosestSync);
+                if (bitmap == null)
+                {
+                    System.Diagnostics.Debug.WriteLine("[FileHelper] ClosestSync returned null, trying Closest...");
+                    bitmap = retriever.GetFrameAtTime(0, Android.Media.Option.Closest);
+                    if (bitmap == null)
+                    {
+                        System.Diagnostics.Debug.WriteLine("[FileHelper] Closest also returned null — no video track or unsupported codec.");
+                        return string.Empty;
+                    }
+                }
+
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] Got bitmap: {bitmap.Width}x{bitmap.Height}");
+
+                var thumbDir = Path.GetDirectoryName(outputThumbPath);
+                if (!string.IsNullOrEmpty(thumbDir))
+                    Directory.CreateDirectory(thumbDir);
+
+                // Scale down to thumbnail size to reduce memory and file size
+                const int maxDim = 120;
+                Android.Graphics.Bitmap scaledBitmap;
+                if (bitmap.Width > maxDim || bitmap.Height > maxDim)
+                {
+                    float scale = Math.Min((float)maxDim / bitmap.Width, (float)maxDim / bitmap.Height);
+                    int newWidth = (int)(bitmap.Width * scale);
+                    int newHeight = (int)(bitmap.Height * scale);
+                    scaledBitmap = Android.Graphics.Bitmap.CreateScaledBitmap(bitmap, newWidth, newHeight, true);
+                    if (scaledBitmap != bitmap)
+                        bitmap.Recycle();
+                }
+                else
+                {
+                    scaledBitmap = bitmap;
+                }
+
+                using var outStream = new FileStream(outputThumbPath, FileMode.Create, FileAccess.Write, FileShare.None);
+                bool compressed = scaledBitmap.Compress(Android.Graphics.Bitmap.CompressFormat.Jpeg!, 85, outStream);
+                outStream.Flush();
+                if (scaledBitmap != bitmap)
+                    scaledBitmap.Recycle();
+
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] Video thumbnail saved: {outputThumbPath}, compressed={compressed}");
+
+                if (File.Exists(outputThumbPath))
+                {
+                    var thumbSize = new FileInfo(outputThumbPath).Length;
+                    if (thumbSize == 0)
+                    {
+                        System.Diagnostics.Debug.WriteLine("[FileHelper] WARNING: Thumbnail file is empty!");
+                        try { File.Delete(outputThumbPath); } catch { }
+                        return string.Empty;
+                    }
+                }
+                else
+                {
+                    System.Diagnostics.Debug.WriteLine("[FileHelper] ERROR: Thumbnail file was not created!");
+                    return string.Empty;
+                }
+
+                return outputThumbPath;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] ExtractVideoFirstFrame EXCEPTION: {ex.GetType().Name}: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] StackTrace: {ex.StackTrace}");
+                return string.Empty;
+            }
+            finally
+            {
+                try { bitmap?.Dispose(); } catch { }
+            }
+        }
+
+        private static string? CopyToMediaStore(
+            Android.Content.Context context, string sourcePath, string fileName, string mimeType)
+        {
+            var isVideo = mimeType.StartsWith("video", StringComparison.OrdinalIgnoreCase);
+            var collection = isVideo
+                ? Android.Provider.MediaStore.Video.Media.ExternalContentUri
+                : Android.Provider.MediaStore.Images.Media.ExternalContentUri;
+
+            var values = new Android.Content.ContentValues();
+            values.Put(Android.Provider.MediaStore.IMediaColumns.DisplayName, Path.GetFileNameWithoutExtension(fileName));
+            values.Put(Android.Provider.MediaStore.IMediaColumns.MimeType, mimeType);
+            values.Put(Android.Provider.MediaStore.IMediaColumns.RelativePath,
+                $"{Android.OS.Environment.DirectoryPictures}/{Settings.DefaultCameraName}");
+            values.Put(Android.Provider.MediaStore.IMediaColumns.IsPending, 1);
+
+            var resolver = context.ContentResolver;
+            var uri = resolver?.Insert(collection!, values);
+            if (uri == null || resolver == null)
+            {
+                System.Diagnostics.Debug.WriteLine("[FileHelper] MediaStore insert returned null URI");
+                return null;
+            }
+
+            try
+            {
+                using (var outputStream = resolver.OpenOutputStream(uri))
+                {
+                    if (outputStream == null)
+                    {
+                        resolver.Delete(uri, null, null);
+                        return null;
+                    }
+
+                    using var inputStream = File.OpenRead(sourcePath);
+                    inputStream.CopyTo(outputStream);
+                    outputStream.Flush();
+                }
+
+                var updateValues = new Android.Content.ContentValues();
+                updateValues.Put(Android.Provider.MediaStore.IMediaColumns.IsPending, 0);
+                resolver.Update(uri, updateValues, null, null);
+
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] MediaStore: published {fileName} to gallery");
+
+                // Retain sourcePath for in-app viewing (not deleted — lives in ExternalCacheDir)
+                return sourcePath;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[FileHelper] MediaStore write failed: {ex.Message}");
+                try { resolver.Delete(uri, null, null); } catch { }
+                return null;
+            }
+        }
+
+        private static void DeleteFromMediaStore(string filePath)
+        {
+            var context = Android.App.Application.Context;
+            var contentResolver = context.ContentResolver;
+            if (contentResolver == null) return;
+
+            var collections = new[]
+            {
+                Android.Provider.MediaStore.Images.Media.ExternalContentUri!,
+                Android.Provider.MediaStore.Video.Media.ExternalContentUri!
+            };
+
+            foreach (var collection in collections)
+            {
+                string selection = $"{Android.Provider.MediaStore.IMediaColumns.Data} = ?";
+                string[] selectionArgs = { filePath };
+                int deleted = contentResolver.Delete(collection, selection, selectionArgs);
+                if (deleted > 0)
+                {
+                    System.Diagnostics.Debug.WriteLine($"[FileHelper] Removed from MediaStore: {filePath}");
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/Projects/TravelCam/TravelCamApp/Platforms/Android/MainActivity.cs
+++ b/Projects/TravelCam/TravelCamApp/Platforms/Android/MainActivity.cs
@@ -5,7 +5,7 @@ using AndroidX.Core.View;
 
 namespace TravelCamApp
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask, ResizeableActivity = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
         protected override void OnCreate(Bundle? savedInstanceState)

--- a/Projects/TravelCam/TravelCamApp/TravelCamApp.csproj
+++ b/Projects/TravelCam/TravelCamApp/TravelCamApp.csproj
@@ -4,7 +4,7 @@
 		<!-- Primary target: Android. iOS/MacCatalyst scaffolding kept but not built by default -->
 		<TargetFrameworks>net10.0-android</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
-		<MauiVersion>10.0.30</MauiVersion>
+		<MauiVersion>10.0.41</MauiVersion>
 
 		<OutputType>Exe</OutputType>
 		<RootNamespace>TravelCamApp</RootNamespace>
@@ -58,8 +58,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Maui" Version="14.0.0" />
-		<PackageReference Include="CommunityToolkit.Maui.Camera" Version="6.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="14.1.0" />
+		<PackageReference Include="CommunityToolkit.Maui.Camera" Version="6.0.1" />
+		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />

--- a/Projects/TravelCam/TravelCamApp/ViewModels/CLAUDE.md
+++ b/Projects/TravelCam/TravelCamApp/ViewModels/CLAUDE.md
@@ -19,6 +19,10 @@
 - `_isDestroyed` flag prevents callbacks after window cleanup.
 - Camera initialized only after `CamerasLoaded` event from the view.
 
+- **Video Recording Support**: The MainPageViewModel handles video recording with proper state management, including preview stopping/restarting, recording timers, and thumbnail generation.
+- **Video Lifecycle**: Manages IsRecording state, recording timer for display, and ensures proper camera preview restart after video recording ends.
+- **Thumbnail Handling**: Video thumbnails are extracted as the first frame and saved alongside the video file in the gallery.
+
 ## DataOverlayViewModel.cs
 - Bridge ViewModel for the DataOverlayView overlay.
 - Subscribes to SensorHelper updates (legacy — some logic merged into MainPageViewModel now).

--- a/Projects/TravelCam/TravelCamApp/ViewModels/MainPageViewModel.cs
+++ b/Projects/TravelCam/TravelCamApp/ViewModels/MainPageViewModel.cs
@@ -70,7 +70,7 @@ namespace TravelCamApp.ViewModels
         private DateTime _recordingStart;
 
         // Gallery viewer
-        private List<string> _galleryImagePaths = new();
+        private ObservableCollection<string> _galleryImagePaths = new();
         private int _currentImageIndex;
 
         // Lifecycle guards
@@ -161,7 +161,7 @@ namespace TravelCamApp.ViewModels
             set { _isImageViewerVisible = value; OnPropertyChanged(); }
         }
 
-        public List<string> GalleryImagePaths
+        public ObservableCollection<string> GalleryImagePaths
         {
             get => _galleryImagePaths;
             set { _galleryImagePaths = value; OnPropertyChanged(); OnPropertyChanged(nameof(ImagePositionText)); }
@@ -176,6 +176,24 @@ namespace TravelCamApp.ViewModels
                 _currentImageIndex = value;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(ImagePositionText));
+                OnPropertyChanged(nameof(CurrentImageItem));
+            }
+        }
+
+        // For two-way binding with CollectionView SelectedItem
+        public string? CurrentImageItem
+        {
+            get => _galleryImagePaths.Count > 0 && _currentImageIndex >= 0 && _currentImageIndex < _galleryImagePaths.Count
+                ? _galleryImagePaths[_currentImageIndex]
+                : null;
+            set
+            {
+                if (value != null && _galleryImagePaths.Contains(value))
+                {
+                    var index = _galleryImagePaths.IndexOf(value);
+                    if (index != _currentImageIndex)
+                        CurrentImageIndex = index;
+                }
             }
         }
 
@@ -596,8 +614,10 @@ namespace TravelCamApp.ViewModels
                 app.PageDisappearing -= OnPageDisappearing;
             }
 
+            // Reset static flag so new instance can subscribe to lifecycle events
+            _lifecycleSubscribed = false;
+
             _sensorHelper.Stop();
-            _sensorValueViewModel.Dispose();
             StopRecordingTimer();
             _cameraView = null;
 
@@ -1112,7 +1132,7 @@ namespace TravelCamApp.ViewModels
             if (imagePaths.Count == 0 && !string.IsNullOrEmpty(_lastThumbPath) && File.Exists(_lastThumbPath))
             {
                 System.Diagnostics.Debug.WriteLine($"[MainPageViewModel] Using fallback thumb: {_lastThumbPath}");
-                imagePaths = new List<string> { _lastThumbPath };
+                imagePaths = new List<string> { _lastThumbPath! };
             }
 
             if (imagePaths.Count == 0)
@@ -1124,7 +1144,7 @@ namespace TravelCamApp.ViewModels
             // Just use file paths directly - MAUI Image control will load them
             System.Diagnostics.Debug.WriteLine($"[MainPageViewModel] Setting gallery paths: {imagePaths.Count} images");
 
-            GalleryImagePaths = imagePaths;
+            GalleryImagePaths = new ObservableCollection<string>(imagePaths);
             CurrentImageIndex = 0; // newest first
             IsImageViewerVisible = true;
 
@@ -1191,13 +1211,13 @@ namespace TravelCamApp.ViewModels
             if (updated.Count == 0)
             {
                 IsImageViewerVisible = false;
-                GalleryImagePaths = new List<string>();
+                GalleryImagePaths = new ObservableCollection<string>();
                 return;
             }
 
             // Adjust index if we deleted the last item
             var newIndex = _currentImageIndex >= updated.Count ? updated.Count - 1 : _currentImageIndex;
-            GalleryImagePaths = updated;
+            GalleryImagePaths = new ObservableCollection<string>(updated);
             CurrentImageIndex = newIndex;
         }
 

--- a/Projects/TravelCam/TravelCamApp/Views/ImageViewerView.xaml
+++ b/Projects/TravelCam/TravelCamApp/Views/ImageViewerView.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:vm="clr-namespace:TravelCamApp.ViewModels"
              xmlns:converters="clr-namespace:TravelCamApp.Converters"
              xmlns:sys="clr-namespace:System;assembly=netstandard"
@@ -13,10 +14,6 @@
         <converters:ThumbnailConverter x:Key="ThumbnailConverter" />
         <converters:ExtensionEqualsConverter x:Key="ExtensionEqualsConverter" />
 
-        <!-- Boolean to Visibility converter for play icon overlay -->
-        <x:Boolean x:Key="True">true</x:Boolean>
-        <x:Boolean x:Key="False">false</x:Boolean>
-
         <!-- Image template for photos -->
         <DataTemplate x:Key="ImageTemplate" x:DataType="sys:String">
             <Image Source="{Binding ., Converter={StaticResource FilePathToImageSourceConverter}}"
@@ -25,27 +22,28 @@
                    VerticalOptions="Fill" />
         </DataTemplate>
 
-        <!-- Video template with play button that opens system player -->
+        <!-- Video template: poster image + tap-to-play overlay only.
+             NO MediaElement here — a single shared MediaElement lives outside the
+             CarouselView so only one ExoPlayer instance ever exists. Having a
+             MediaElement per carousel item exhausts ExoPlayer on rapid swipes. -->
         <DataTemplate x:Key="VideoTemplate" x:DataType="sys:String">
             <Grid BackgroundColor="Black">
-                <!-- Video thumbnail -->
+                <!-- Poster thumbnail -->
                 <Image Source="{Binding ., Converter={StaticResource ThumbnailConverter}}"
                        Aspect="AspectFit"
                        HorizontalOptions="Fill"
                        VerticalOptions="Fill" />
-                <!-- Play button overlay -->
-                <Border BackgroundColor="#80000000"
-                        CornerRadius="40"
-                        WidthRequest="80" HeightRequest="80"
-                        HorizontalOptions="Center"
-                        VerticalOptions="Center">
-                    <Path Data="M20,16 L34,24 L20,32 Z"
-                          Fill="White"
-                          WidthRequest="32" HeightRequest="32"
-                          HorizontalOptions="Center"
-                          VerticalOptions="Center" />
+                <!-- Tap-to-play overlay -->
+                <Border BackgroundColor="#88000000" Stroke="Transparent"
+                        StrokeShape="Ellipse"
+                        WidthRequest="72" HeightRequest="72"
+                        HorizontalOptions="Center" VerticalOptions="Center">
+                    <Path Data="M10,8 L26,17 L10,26 Z"
+                          Fill="White" Aspect="Uniform"
+                          WidthRequest="28" HeightRequest="28"
+                          HorizontalOptions="Center" VerticalOptions="Center" />
                     <Border.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding PlayVideoCommand}" CommandParameter="{Binding .}" />
+                        <TapGestureRecognizer Tapped="OnVideoPlayTapped" />
                     </Border.GestureRecognizers>
                 </Border>
             </Grid>
@@ -99,31 +97,47 @@
                 </Border>
             </Grid>
 
-            <!-- ── Row 1: Main media viewer (CarouselView) ── -->
-            <CarouselView Grid.Row="1"
-                          x:Name="MainCarousel"
-                          ItemsSource="{Binding GalleryImagePaths}"
-                          Position="{Binding CurrentImageIndex, Mode=TwoWay}"
-                          PositionChanged="OnCarouselPositionChanged"
-                          Loop="False"
-                          HorizontalScrollBarVisibility="Never"
-                          VerticalScrollBarVisibility="Never"
-                          BackgroundColor="Black">
-                <CarouselView.ItemTemplate>
-                    <StaticResource Key="MediaTemplateSelector" />
-                </CarouselView.ItemTemplate>
-            </CarouselView>
+            <!-- ── Row 1: CarouselView + shared video player overlay ── -->
+            <Grid Grid.Row="1" BackgroundColor="Black">
+
+                <CarouselView x:Name="MainCarousel"
+                              ItemsSource="{Binding GalleryImagePaths}"
+                              Position="{Binding CurrentImageIndex, Mode=TwoWay}"
+                              PositionChanged="OnCarouselPositionChanged"
+                              Loop="False"
+                              HorizontalScrollBarVisibility="Never"
+                              VerticalScrollBarVisibility="Never"
+                              BackgroundColor="Black">
+                    <CarouselView.ItemTemplate>
+                        <StaticResource Key="MediaTemplateSelector" />
+                    </CarouselView.ItemTemplate>
+                </CarouselView>
+
+                <!-- Single shared MediaElement: only ONE ExoPlayer instance ever exists.
+                     Hidden by default; shown when user taps play on a video item.
+                     Stopped and hidden again when swiping or closing gallery. -->
+                <toolkit:MediaElement x:Name="SharedVideoPlayer"
+                                      IsVisible="False"
+                                      Aspect="AspectFit"
+                                      HorizontalOptions="Fill"
+                                      VerticalOptions="Fill"
+                                      BackgroundColor="Black"
+                                      ShouldShowPlaybackControls="True"
+                                      ShouldAutoPlay="True" />
+            </Grid>
 
             <!-- ── Row 2: Thumbnail strip ── -->
             <CollectionView Grid.Row="2"
                             x:Name="ThumbnailStrip"
                             ItemsSource="{Binding GalleryImagePaths}"
+                            SelectedItem="{Binding CurrentImageItem, Mode=TwoWay}"
                             HeightRequest="72"
                             BackgroundColor="#1A1A1A"
                             SelectionMode="Single"
                             SelectionChanged="OnThumbnailSelected">
                 <CollectionView.ItemsLayout>
-                    <LinearItemsLayout Orientation="Horizontal" ItemSpacing="0" />
+                    <LinearItemsLayout Orientation="Horizontal" ItemSpacing="0"
+                                       ItemSizingStrategy="MeasureFirstItem" />
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="sys:String">
@@ -137,14 +151,17 @@
                                 <Image Source="{Binding ., Converter={StaticResource ThumbnailConverter}}"
                                        Aspect="AspectFill"
                                        WidthRequest="56" HeightRequest="56" />
-                                <!-- Play icon overlay for videos -->
-                                <Path Data="M20,16 L34,24 L20,32 Z"
-                                      Fill="White"
-                                      WidthRequest="24" HeightRequest="24"
-                                      HorizontalOptions="Center"
-                                      VerticalOptions="Center"
-                                      BackgroundColor="#66000000"
-                                      IsVisible="{Binding ., Converter={StaticResource ExtensionEqualsConverter}, ConverterParameter=.mp4}" />
+                                <!-- Circular play icon overlay for videos -->
+                                <Border BackgroundColor="#99000000" Stroke="Transparent"
+                                        StrokeShape="Ellipse"
+                                        WidthRequest="24" HeightRequest="24"
+                                        HorizontalOptions="Center" VerticalOptions="Center"
+                                        IsVisible="{Binding ., Converter={StaticResource ExtensionEqualsConverter}, ConverterParameter=.mp4}">
+                                    <Path Data="M6,4 L18,12 L6,20 Z"
+                                          Fill="White" Aspect="Uniform"
+                                          WidthRequest="10" HeightRequest="10"
+                                          HorizontalOptions="Center" VerticalOptions="Center" />
+                                </Border>
                             </Grid>
                         </Border>
                     </DataTemplate>

--- a/Projects/TravelCam/TravelCamApp/Views/ImageViewerView.xaml.cs
+++ b/Projects/TravelCam/TravelCamApp/Views/ImageViewerView.xaml.cs
@@ -1,8 +1,9 @@
 // ========================================== //
 // Developer: Yohanes Wahyu Nurcahyo          //
-// Website: https://github.com/yoyokits       //
+// Website: https://github.com/yoyokitos       //
 // ========================================== //
 
+using CommunityToolkit.Maui.Views;
 using TravelCamApp.ViewModels;
 
 namespace TravelCamApp.Views
@@ -12,6 +13,13 @@ namespace TravelCamApp.Views
         public ImageViewerView()
         {
             InitializeComponent();
+
+            // Stop the shared video player automatically when the gallery is closed.
+            PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(IsVisible) && !IsVisible)
+                    StopSharedVideoPlayer();
+            };
         }
 
         private void OnThumbnailSelected(object? sender, SelectionChangedEventArgs e)
@@ -31,15 +39,62 @@ namespace TravelCamApp.Views
 
         private void OnCarouselPositionChanged(object? sender, EventArgs e)
         {
-            // Sync thumbnail scroll position when carousel position changes (user swipes)
+            // Scroll the thumbnail strip to keep it in sync
             if (BindingContext is MainPageViewModel vm && MainCarousel != null && ThumbnailStrip != null)
             {
                 var newIndex = MainCarousel.Position;
                 if (newIndex >= 0 && newIndex < vm.GalleryImagePaths.Count)
-                {
                     ThumbnailStrip.ScrollTo(newIndex, position: ScrollToPosition.Center, animate: true);
-                }
             }
+
+            // Hide the shared video player when navigating to another item
+            StopSharedVideoPlayer();
+        }
+
+        /// <summary>
+        /// Tapping the play overlay: assigns source to the single shared MediaElement
+        /// and makes it visible. Only one ExoPlayer instance is ever active at a time,
+        /// which prevents the resource exhaustion crash that happens when per-item
+        /// MediaElements accumulate during rapid swiping.
+        /// </summary>
+        private void OnVideoPlayTapped(object? sender, TappedEventArgs e)
+        {
+            if (sender is not Border playOverlay) return;
+            if (playOverlay.Parent is not Grid parentGrid) return;
+            if (parentGrid.BindingContext is not string filePath) return;
+
+            try
+            {
+                SharedVideoPlayer.Source = new FileMediaSource { Path = filePath };
+                SharedVideoPlayer.IsVisible = true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[ImageViewerView] OnVideoPlayTapped error: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Stops and hides the shared MediaElement, freeing the ExoPlayer resource.
+        /// Called on swipe, thumbnail tap, and gallery close.
+        /// </summary>
+        private void StopSharedVideoPlayer()
+        {
+            if (!SharedVideoPlayer.IsVisible) return;
+
+            try
+            {
+                SharedVideoPlayer.Stop();
+                SharedVideoPlayer.Source = null;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[ImageViewerView] StopSharedVideoPlayer error: {ex.Message}");
+            }
+
+            SharedVideoPlayer.IsVisible = false;
         }
     }
 }


### PR DESCRIPTION
- Use a single shared MediaElement for video playback in gallery to prevent ExoPlayer resource exhaustion on Android
- Refactor FileHelper: move Android-specific MediaStore and thumbnail logic to FileHelper.android.cs (partial class)
- Change gallery binding to ObservableCollection for live updates; add two-way sync between carousel and thumbnail strip
- Upgrade CommunityToolkit.Maui, Camera, and add MediaElement; target Android SDK 36, .NET MAUI 10.0.41
- Improve crash diagnostics (App.xaml.cs), update docs, and clean up legacy code