### PR TITLE
Refactor camera UI: move zoom pills, integrate mode toggles

### DIFF
--- a/Projects/TravelCam/.claude/settings.local.json
+++ b/Projects/TravelCam/.claude/settings.local.json
@@ -31,7 +31,13 @@
       "Bash(dotnet restore:*)",
       "Bash(powershell:*)",
       "Bash(ls \"C:/Users/yoyok/Git/Playground/Projects/TravelCam/\"*.bak)",
-      "Bash(dotnet workload:*)"
+      "Bash(dotnet workload:*)",
+      "WebFetch(domain:pictogrammers.com)",
+      "WebFetch(domain:materialui.co)",
+      "WebFetch(domain:www.mdisvg.com)",
+      "WebFetch(domain:icon-sets.iconify.design)",
+      "WebFetch(domain:fonts.google.com)",
+      "WebFetch(domain:github.com)"
     ]
   },
   "ENABLE_TOOL_SEARCH": "true"

--- a/Projects/TravelCam/TravelCamApp/Converters/CaptureModeConverters.cs
+++ b/Projects/TravelCam/TravelCamApp/Converters/CaptureModeConverters.cs
@@ -151,4 +151,41 @@ namespace TravelCamApp.Converters
             throw new NotImplementedException();
         }
     }
+
+    /// <summary>
+    /// Returns the background color for an aspect-ratio segment button.
+    /// Active → accent blue, Inactive → dark card.
+    /// Parameter is the AspectRatioOption name string.
+    /// </summary>
+    public sealed class AspectRatioToBackgroundConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is AspectRatioOption current && parameter is string p &&
+                System.Enum.TryParse<AspectRatioOption>(p, out var target))
+                return current == target ? Color.FromArgb("#0A84FF") : Color.FromArgb("#2C2C2E");
+            return Color.FromArgb("#2C2C2E");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Returns the text color for an aspect-ratio segment button.
+    /// Active → White, Inactive → medium gray.
+    /// </summary>
+    public sealed class AspectRatioToTextColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is AspectRatioOption current && parameter is string p &&
+                System.Enum.TryParse<AspectRatioOption>(p, out var target))
+                return current == target ? Colors.White : Color.FromArgb("#88FFFFFF");
+            return Color.FromArgb("#88FFFFFF");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => throw new NotImplementedException();
+    }
 }

--- a/Projects/TravelCam/TravelCamApp/Helpers/CameraHelper.cs
+++ b/Projects/TravelCam/TravelCamApp/Helpers/CameraHelper.cs
@@ -367,6 +367,24 @@ namespace TravelCamApp.Helpers
         #region Zoom
 
         /// <summary>
+        /// Returns the total number of camera devices available on the current hardware.
+        /// Used by the ViewModel to decide whether to show the zoom preset strip.
+        /// </summary>
+        public static async Task<int> GetCameraCountAsync(CameraView cameraView)
+        {
+            try
+            {
+                var cameras = await cameraView.GetAvailableCameras(CancellationToken.None);
+                return cameras?.Count ?? 0;
+            }
+            catch (Exception ex)
+            {
+                LogDebug("[CameraHelper] GetCameraCountAsync exception: {0}", ex.Message);
+                return 0;
+            }
+        }
+
+        /// <summary>
         /// Applies zoom to the camera.
         /// <paramref name="zoomFactor"/> is passed directly to <see cref="CameraView.ZoomFactor"/>.
         /// The ViewModel is responsible for ensuring the value is within the camera's supported range.

--- a/Projects/TravelCam/TravelCamApp/ViewModels/CameraSettingsViewModel.cs
+++ b/Projects/TravelCam/TravelCamApp/ViewModels/CameraSettingsViewModel.cs
@@ -1,25 +1,27 @@
 // ========================================== //
 // Developer: Yohanes Wahyu Nurcahyo          //
-// Website: https://github.com/yoyokits       //
+// Website: https://github.com/yoyokids       //
 // ========================================== //
 //
 // CameraSettingsViewModel: Manages all camera display/behaviour
 // settings that are not sensor-related.
 //
-// Currently supported:
+// Supported:
 //   • ShowRuleOfThirds  — toggle the overlay grid
 //   • ShowSensorOverlay — toggle the sensor data panel
 //   • GridLineOpacity   — how visible the rule-of-thirds lines are
-//
-// Planned (requires future API support or platform-specific code):
-//   • Resolution / AspectRatio picker
+//   • SelectedAspectRatio — visual crop applied to the camera preview
 
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Storage;
 
 namespace TravelCamApp.ViewModels
 {
+    public enum AspectRatioOption { FullScreen, FourThree, SixteenNine, OneOne }
+
     public class CameraSettingsViewModel : INotifyPropertyChanged
     {
         #region Fields
@@ -27,10 +29,12 @@ namespace TravelCamApp.ViewModels
         private bool _showRuleOfThirds = true;
         private bool _showSensorOverlay = true;
         private double _gridLineOpacity = 0.18;
+        private AspectRatioOption _selectedAspectRatio = AspectRatioOption.FullScreen;
 
-        private const string PrefShowGrid    = "CamShowGrid";
-        private const string PrefShowSensors = "CamShowSensors";
-        private const string PrefGridOpacity = "CamGridOpacity";
+        private const string PrefShowGrid      = "CamShowGrid";
+        private const string PrefShowSensors   = "CamShowSensors";
+        private const string PrefGridOpacity   = "CamGridOpacity";
+        private const string PrefAspectRatio   = "CamAspectRatio";
 
         #endregion
 
@@ -64,6 +68,19 @@ namespace TravelCamApp.ViewModels
             }
         }
 
+        /// <summary>Selected aspect ratio for the camera preview crop overlay.</summary>
+        public AspectRatioOption SelectedAspectRatio
+        {
+            get => _selectedAspectRatio;
+            set
+            {
+                if (_selectedAspectRatio == value) return;
+                _selectedAspectRatio = value;
+                OnPropertyChanged();
+                Preferences.Set(PrefAspectRatio, (int)value);
+            }
+        }
+
         /// <summary>Opacity of the rule-of-thirds grid lines (0.05 – 0.50).</summary>
         public double GridLineOpacity
         {
@@ -84,18 +101,34 @@ namespace TravelCamApp.ViewModels
 
         #endregion
 
+        #region Commands
+
+        /// <summary>
+        /// Sets the selected aspect ratio from a string CommandParameter
+        /// (e.g. "FullScreen", "FourThree", "SixteenNine", "OneOne").
+        /// </summary>
+        public ICommand SetAspectRatioCommand { get; }
+
+        #endregion
+
         #region Constructor / Persistence
 
         public CameraSettingsViewModel()
         {
+            SetAspectRatioCommand = new Command<string>(p =>
+            {
+                if (System.Enum.TryParse<AspectRatioOption>(p, out var ratio))
+                    SelectedAspectRatio = ratio;
+            });
             LoadPersistedSettings();
         }
 
         private void LoadPersistedSettings()
         {
-            _showRuleOfThirds = Preferences.Get(PrefShowGrid,    true);
+            _showRuleOfThirds  = Preferences.Get(PrefShowGrid,    true);
             _showSensorOverlay = Preferences.Get(PrefShowSensors, true);
-            _gridLineOpacity  = Preferences.Get(PrefGridOpacity,  0.18);
+            _gridLineOpacity   = Preferences.Get(PrefGridOpacity,  0.18);
+            _selectedAspectRatio = (AspectRatioOption)Preferences.Get(PrefAspectRatio, (int)AspectRatioOption.FullScreen);
         }
 
         #endregion

--- a/Projects/TravelCam/TravelCamApp/ViewModels/MainPageViewModel.cs
+++ b/Projects/TravelCam/TravelCamApp/ViewModels/MainPageViewModel.cs
@@ -65,6 +65,13 @@ namespace TravelCamApp.ViewModels
         // Flash
         private bool _isFlashOn;
 
+        // Camera count — used to show/hide zoom strip
+        private int _cameraCount;
+
+        // Aspect ratio crop bars
+        private double _aspectTopBarHeight;
+        private double _aspectBottomBarHeight;
+
         // Recording display timer
         private System.Timers.Timer? _recordingTimer;
         private DateTime _recordingStart;
@@ -232,6 +239,37 @@ namespace TravelCamApp.ViewModels
             get => _isFlashOn;
             set { _isFlashOn = value; OnPropertyChanged(); }
         }
+
+        /// <summary>True when the device has more than one camera (shows zoom preset strip).</summary>
+        public bool ShowZoomPresets => _cameraCount > 1;
+
+        /// <summary>Height of the top black letterbox bar for the selected aspect ratio.</summary>
+        public double AspectTopBarHeight
+        {
+            get => _aspectTopBarHeight;
+            set
+            {
+                if (Math.Abs(_aspectTopBarHeight - value) < 0.5) return;
+                _aspectTopBarHeight = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(HasAspectBars));
+            }
+        }
+
+        /// <summary>Height of the bottom black letterbox bar for the selected aspect ratio.</summary>
+        public double AspectBottomBarHeight
+        {
+            get => _aspectBottomBarHeight;
+            set
+            {
+                if (Math.Abs(_aspectBottomBarHeight - value) < 0.5) return;
+                _aspectBottomBarHeight = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>True when letterbox bars should be shown (any non-FullScreen aspect ratio with non-zero bars).</summary>
+        public bool HasAspectBars => _aspectTopBarHeight > 1;
 
         /// <summary>
         /// Dynamic zoom presets generated from the active camera's min/max zoom range.
@@ -934,8 +972,12 @@ namespace TravelCamApp.ViewModels
                     }
 #endif
 
+                    // Get total camera count to decide whether to show zoom strip
+                    _cameraCount = await CameraHelper.GetCameraCountAsync(_cameraView);
+                    OnPropertyChanged(nameof(ShowZoomPresets));
+
                     // Build zoom presets from actual hardware capabilities
-                    UpdateZoomPresets(selected);
+                    UpdateZoomPresets(_cameraCount);
                 }
 
                 if (_isDestroyed || _cameraView == null) return;
@@ -993,7 +1035,7 @@ namespace TravelCamApp.ViewModels
 
                 var newCamera = await CameraHelper.ToggleCameraDeviceAsync(_cameraView);
                 if (newCamera != null)
-                    UpdateZoomPresets(newCamera);
+                    UpdateZoomPresets(_cameraCount);
 
                 bool ok = await CameraHelper.StartPreviewAsync(_cameraView);
                 IsPreviewRunning = ok;
@@ -1013,18 +1055,21 @@ namespace TravelCamApp.ViewModels
         #region Zoom
 
         /// <summary>
-        /// Rebuilds <see cref="ZoomPresets"/> with standard zoom stops.
+        /// Rebuilds <see cref="ZoomPresets"/> with standard zoom stops based on camera count.
+        /// CommunityToolkit.Maui ZoomFactor is an absolute multiplier (1.0 = 1× optical).
         /// </summary>
-        private void UpdateZoomPresets(CameraInfo camera)
+        private void UpdateZoomPresets(int cameraCount)
         {
-            // CommunityToolkit.Maui CameraInfo doesn't expose min/max zoom bounds.
-            // Use standard preset stops (1×, 2×, 3×, 5×) normalized to 0.0–1.0 range.
-            float[] presetZooms = { 0.2f, 0.5f, 1.0f };
+            // Choose presets based on how many camera devices the hardware reports.
+            // Single-camera devices have ShowZoomPresets=false so this list is never shown,
+            // but we populate it anyway in case the count updates later.
+            float[] presetZooms = cameraCount >= 3
+                ? new[] { 0.6f, 1.0f, 2.0f, 5.0f }   // ultra-wide + main + tele
+                : new[] { 1.0f, 2.0f, 5.0f };          // main + tele (2-camera or fallback)
 
             System.Diagnostics.Debug.WriteLine(
-                "[MainPageViewModel] Camera zoom presets: 0.2×, 0.5×, 1.0×");
+                $"[MainPageViewModel] Building zoom presets for {cameraCount} cameras");
 
-            // Build collection — each ZoomPreset stores the normalized camera zoom factor
             ZoomPresets.Clear();
             foreach (var zoom in presetZooms)
             {
@@ -1033,7 +1078,7 @@ namespace TravelCamApp.ViewModels
                 ZoomPresets.Add(preset);
             }
 
-            // Select 1.0 by default
+            // Select 1× by default
             var defaultPreset = ZoomPresets
                 .FirstOrDefault(p => Math.Abs(p.AbsoluteZoom - 1.0f) < 0.01f);
             if (defaultPreset != null)

--- a/Projects/TravelCam/TravelCamApp/Views/CameraSettingsView.xaml
+++ b/Projects/TravelCam/TravelCamApp/Views/CameraSettingsView.xaml
@@ -3,12 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:vm="clr-namespace:TravelCamApp.ViewModels"
+             xmlns:converters="clr-namespace:TravelCamApp.Converters"
              x:Class="TravelCamApp.Views.CameraSettingsView"
              x:DataType="vm:CameraSettingsViewModel"
              x:Name="CamSettingsRoot">
 
     <ContentView.Resources>
         <toolkit:InvertedBoolConverter x:Key="InvBool" />
+        <converters:AspectRatioToBackgroundConverter x:Key="AspectRatioToBgConverter" />
+        <converters:AspectRatioToTextColorConverter  x:Key="AspectRatioToTextConverter" />
     </ContentView.Resources>
 
     <ContentView.Content>
@@ -160,20 +163,81 @@
                                 <BoxView HeightRequest="0.5" BackgroundColor="#2C2C2E"
                                          Margin="16,0" />
 
-                                <!-- Aspect ratio placeholder -->
-                                <Grid ColumnDefinitions="*,Auto"
-                                      Padding="16,14" HeightRequest="52">
-                                    <VerticalStackLayout Grid.Column="0" Spacing="2"
-                                                          VerticalOptions="Center">
-                                        <Label Text="Aspect Ratio" FontSize="14"
-                                               TextColor="#636366" />
-                                        <Label Text="Coming soon"
-                                               FontSize="11" TextColor="#48484A" />
-                                    </VerticalStackLayout>
-                                    <Label Grid.Column="1" Text="4:3"
-                                           FontSize="13" TextColor="#636366"
-                                           VerticalOptions="Center" />
-                                </Grid>
+                                <!-- Aspect Ratio selector -->
+                                <VerticalStackLayout Padding="16,14,16,14" Spacing="10">
+                                    <Label Text="Aspect Ratio" FontSize="14"
+                                           TextColor="#FFFFFF" />
+                                    <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="6">
+                                        <!-- Full -->
+                                        <Border Grid.Column="0"
+                                                StrokeShape="RoundRectangle 8" Stroke="Transparent"
+                                                Padding="0,6"
+                                                BackgroundColor="{Binding SelectedAspectRatio,
+                                                    Converter={StaticResource AspectRatioToBgConverter},
+                                                    ConverterParameter=FullScreen}">
+                                            <Label Text="Full" FontSize="12" FontAttributes="Bold"
+                                                   TextColor="{Binding SelectedAspectRatio,
+                                                       Converter={StaticResource AspectRatioToTextConverter},
+                                                       ConverterParameter=FullScreen}"
+                                                   HorizontalOptions="Center" />
+                                            <Border.GestureRecognizers>
+                                                <TapGestureRecognizer Command="{Binding SetAspectRatioCommand}"
+                                                                      CommandParameter="FullScreen" />
+                                            </Border.GestureRecognizers>
+                                        </Border>
+                                        <!-- 4:3 -->
+                                        <Border Grid.Column="1"
+                                                StrokeShape="RoundRectangle 8" Stroke="Transparent"
+                                                Padding="0,6"
+                                                BackgroundColor="{Binding SelectedAspectRatio,
+                                                    Converter={StaticResource AspectRatioToBgConverter},
+                                                    ConverterParameter=FourThree}">
+                                            <Label Text="4:3" FontSize="12" FontAttributes="Bold"
+                                                   TextColor="{Binding SelectedAspectRatio,
+                                                       Converter={StaticResource AspectRatioToTextConverter},
+                                                       ConverterParameter=FourThree}"
+                                                   HorizontalOptions="Center" />
+                                            <Border.GestureRecognizers>
+                                                <TapGestureRecognizer Command="{Binding SetAspectRatioCommand}"
+                                                                      CommandParameter="FourThree" />
+                                            </Border.GestureRecognizers>
+                                        </Border>
+                                        <!-- 16:9 -->
+                                        <Border Grid.Column="2"
+                                                StrokeShape="RoundRectangle 8" Stroke="Transparent"
+                                                Padding="0,6"
+                                                BackgroundColor="{Binding SelectedAspectRatio,
+                                                    Converter={StaticResource AspectRatioToBgConverter},
+                                                    ConverterParameter=SixteenNine}">
+                                            <Label Text="16:9" FontSize="12" FontAttributes="Bold"
+                                                   TextColor="{Binding SelectedAspectRatio,
+                                                       Converter={StaticResource AspectRatioToTextConverter},
+                                                       ConverterParameter=SixteenNine}"
+                                                   HorizontalOptions="Center" />
+                                            <Border.GestureRecognizers>
+                                                <TapGestureRecognizer Command="{Binding SetAspectRatioCommand}"
+                                                                      CommandParameter="SixteenNine" />
+                                            </Border.GestureRecognizers>
+                                        </Border>
+                                        <!-- 1:1 -->
+                                        <Border Grid.Column="3"
+                                                StrokeShape="RoundRectangle 8" Stroke="Transparent"
+                                                Padding="0,6"
+                                                BackgroundColor="{Binding SelectedAspectRatio,
+                                                    Converter={StaticResource AspectRatioToBgConverter},
+                                                    ConverterParameter=OneOne}">
+                                            <Label Text="1:1" FontSize="12" FontAttributes="Bold"
+                                                   TextColor="{Binding SelectedAspectRatio,
+                                                       Converter={StaticResource AspectRatioToTextConverter},
+                                                       ConverterParameter=OneOne}"
+                                                   HorizontalOptions="Center" />
+                                            <Border.GestureRecognizers>
+                                                <TapGestureRecognizer Command="{Binding SetAspectRatioCommand}"
+                                                                      CommandParameter="OneOne" />
+                                            </Border.GestureRecognizers>
+                                        </Border>
+                                    </Grid>
+                                </VerticalStackLayout>
 
                             </VerticalStackLayout>
                         </Border>

--- a/Projects/TravelCam/TravelCamApp/Views/DataOverlayView.xaml
+++ b/Projects/TravelCam/TravelCamApp/Views/DataOverlayView.xaml
@@ -12,40 +12,45 @@
         FontSize is driven by DataOverlayViewModel.LabelFontSize / ValueFontSize (slider-controlled).
         Tap the overlay to open sensor settings.
     -->
+    <!--
+        Border wraps a VerticalStackLayout with BindableLayout (not CollectionView).
+        CollectionView always stretches to fill its container width;
+        VerticalStackLayout + BindableLayout sizes to the widest child label naturally.
+        HorizontalOptions="Start" on the inner layout prevents it from expanding.
+        The ContentView in MainPage.xaml has HorizontalOptions="End", so the
+        Grid measures this view with unconstrained width → it returns its natural
+        label width → the Border and ContentView shrink-wrap accordingly.
+    -->
     <Border BackgroundColor="#99000000"
             StrokeShape="RoundRectangle 10"
             Stroke="Transparent"
-            Padding="10,10"
-            MaximumWidthRequest="160">
-        <VerticalStackLayout Spacing="4">
+            Padding="10,10">
+        <VerticalStackLayout Spacing="4"
+                             HorizontalOptions="Start"
+                             BindableLayout.ItemsSource="{Binding DataOverlayViewModel.VisibleOverlayItems}">
             <VerticalStackLayout.GestureRecognizers>
                 <TapGestureRecognizer Command="{Binding OpenSettingsCommand}" />
             </VerticalStackLayout.GestureRecognizers>
-
-            <CollectionView ItemsSource="{Binding DataOverlayViewModel.VisibleOverlayItems}"
-                            SelectionMode="None">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="models:OverlayItem">
-                        <!-- Each sensor entry: label line + value line -->
-                        <VerticalStackLayout Spacing="0">
-                            <!-- Sensor label (muted gray, uppercase) — size from DataOverlayViewModel.LabelFontSize -->
-                            <Label Text="{Binding Name}"
-                                   FontSize="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DataOverlayViewModel.LabelFontSize}"
-                                   CharacterSpacing="0.6"
-                                   TextColor="#9E9E9E"
-                                   LineBreakMode="NoWrap"
-                                   TextTransform="Uppercase" />
-                            <!-- Sensor value (white, bold) — size from DataOverlayViewModel.ValueFontSize -->
-                            <Label Text="{Binding Value}"
-                                   FontSize="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DataOverlayViewModel.ValueFontSize}"
-                                   FontAttributes="Bold"
-                                   TextColor="#FFFFFF"
-                                   LineBreakMode="NoWrap" />
-                        </VerticalStackLayout>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-
+            <BindableLayout.ItemTemplate>
+                <DataTemplate x:DataType="models:OverlayItem">
+                    <!-- Each sensor entry: label line + value line -->
+                    <VerticalStackLayout Spacing="0" HorizontalOptions="Start">
+                        <!-- Sensor label (muted gray, uppercase) -->
+                        <Label Text="{Binding Name}"
+                               FontSize="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DataOverlayViewModel.LabelFontSize}"
+                               CharacterSpacing="0.6"
+                               TextColor="#9E9E9E"
+                               LineBreakMode="NoWrap"
+                               TextTransform="Uppercase" />
+                        <!-- Sensor value (white, bold) -->
+                        <Label Text="{Binding Value}"
+                               FontSize="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DataOverlayViewModel.ValueFontSize}"
+                               FontAttributes="Bold"
+                               TextColor="#FFFFFF"
+                               LineBreakMode="NoWrap" />
+                    </VerticalStackLayout>
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
         </VerticalStackLayout>
     </Border>
 

--- a/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml
+++ b/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml
@@ -25,6 +25,18 @@
                                 VerticalOptions="Fill"
                                 SizeChanged="OnCameraViewSizeChanged" />
 
+            <!-- ── Aspect-ratio letterbox bars (top + bottom) ──
+                 Black bars that visually crop the preview to the selected aspect ratio.
+                 Heights computed in code-behind via UpdateAspectRatioBars(). -->
+            <BoxView VerticalOptions="Start" HorizontalOptions="Fill"
+                     BackgroundColor="Black" InputTransparent="True"
+                     HeightRequest="{Binding AspectTopBarHeight}"
+                     IsVisible="{Binding HasAspectBars}" />
+            <BoxView VerticalOptions="End" HorizontalOptions="Fill"
+                     BackgroundColor="Black" InputTransparent="True"
+                     HeightRequest="{Binding AspectBottomBarHeight}"
+                     IsVisible="{Binding HasAspectBars}" />
+
             <!-- ── CameraViewChildrenContainer: Container that aligns with visible camera feed ──
                  This container dynamically positions and sizes itself to match the visible camera
                  feed area (excluding black bars from AspectFit letterboxing/pillarboxing).
@@ -33,6 +45,36 @@
                   HorizontalOptions="Center"
                   VerticalOptions="Center"
                   InputTransparent="False">
+
+                <!-- ── Zoom pills strip — top center of visible camera feed ──
+                     Only shown when device has more than one camera (ShowZoomPresets). -->
+                <Border VerticalOptions="Start" HorizontalOptions="Center"
+                        Margin="0,12,0,0"
+                        StrokeShape="RoundRectangle 16" Stroke="Transparent"
+                        BackgroundColor="#66000000" Padding="6,4"
+                        IsVisible="{Binding ShowZoomPresets}">
+                    <HorizontalStackLayout Spacing="2"
+                        BindableLayout.ItemsSource="{Binding ZoomPresets}">
+                        <BindableLayout.ItemTemplate>
+                            <DataTemplate x:DataType="models:ZoomPreset">
+                                <Border StrokeShape="RoundRectangle 13" Stroke="Transparent"
+                                        MinimumWidthRequest="36" HeightRequest="28"
+                                        Padding="6,0"
+                                        BackgroundColor="{Binding PillBackground}">
+                                    <Label Text="{Binding Label}"
+                                           FontSize="{Binding LabelSize}"
+                                           FontAttributes="Bold"
+                                           TextColor="{Binding LabelColor}"
+                                           HorizontalOptions="Center"
+                                           VerticalOptions="Center" />
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer Command="{Binding SelectCommand}" />
+                                    </Border.GestureRecognizers>
+                                </Border>
+                            </DataTemplate>
+                        </BindableLayout.ItemTemplate>
+                    </HorizontalStackLayout>
+                </Border>
 
                 <!-- ── Rule-of-thirds grid lines (inside container)
                      Fills entire container (HorizontalOptions="Fill" VerticalOptions="Fill").
@@ -70,8 +112,6 @@
                 <views:DataOverlayView
                     HorizontalOptions="End" VerticalOptions="End"
                     Margin="0,0,12,12"
-                    MaximumWidthRequest="160"
-                    MaximumHeightRequest="150"
                     IsVisible="{Binding CameraSettings.ShowSensorOverlay}" />
 
             </Grid>
@@ -94,30 +134,34 @@
             </AbsoluteLayout>
 
             <!-- ══════════════════════════════════════════════════════════
-                 TOP TOOLBAR — flash  |  (spacer + recording)  |  settings
+                 TOP TOOLBAR — flash | sensors | (recording timer) | settings
                  Matches Samsung: icons at top, semi-transparent pill buttons
             ══════════════════════════════════════════════════════════════ -->
             <Grid VerticalOptions="Start"
                   Padding="16,8,16,0"
-                  ColumnDefinitions="Auto,*,Auto"
+                  ColumnDefinitions="Auto,Auto,*,Auto"
                   IsVisible="{Binding HasCameraPermission}">
 
-                <!-- Flash toggle — bolt + diagonal slash -->
+                <!-- Col 0: Flash toggle — Material Design flash_on / flash_off paths (24×24 viewbox) -->
                 <Grid Grid.Column="0" WidthRequest="44" HeightRequest="44">
                     <Border StrokeShape="RoundRectangle 22"
                             BackgroundColor="#55000000" Stroke="Transparent"
                             WidthRequest="44" HeightRequest="44" />
-                    <!-- Lightning bolt: clean, centered Samsung-style design -->
-                    <Path Data="M10,2 L6,9 L10.5,9 L5,18 L15,6 L10.5,6 Z"
+                    <!-- Flash ON: Material flash_on — solid yellow bolt.
+                         Phantom subpaths M2,22Z and M19,2Z extend bounding box to x:2-19
+                         so Aspect="Uniform" scales identically to the flash-off path. -->
+                    <Path Data="M7,2V13H10V22L17,10H13L17,2H7Z M2,22Z M19,2Z"
+                          Fill="#FFD60A"
+                          Aspect="Uniform"
+                          WidthRequest="22" HeightRequest="22"
+                          HorizontalOptions="Center" VerticalOptions="Center"
+                          IsVisible="{Binding IsFlashOn}" />
+                    <!-- Flash OFF: Material flash_off — bolt with diagonal slash, white -->
+                    <Path Data="M17,10H13L17,2H7V4.18L15.46,12.64M3.27,3L2,4.27L7,9.27V13H10V22L13.58,15.86L17.73,20L19,18.73L3.27,3Z"
                           Fill="White"
                           Aspect="Uniform"
-                          WidthRequest="18" HeightRequest="18"
-                          HorizontalOptions="Center" VerticalOptions="Center" />
-                    <!-- Slash line — visible only when flash is OFF (clean diagonal) -->
-                    <Path Data="M5,13 L18,5"
-                          Stroke="White" StrokeThickness="2.5" StrokeLineCap="Round"
+                          WidthRequest="22" HeightRequest="22"
                           HorizontalOptions="Center" VerticalOptions="Center"
-                          WidthRequest="18" HeightRequest="18"
                           IsVisible="{Binding IsFlashOn,
                                       Converter={StaticResource InvertedBoolConverter}}" />
                     <Grid.GestureRecognizers>
@@ -125,8 +169,22 @@
                     </Grid.GestureRecognizers>
                 </Grid>
 
-                <!-- Recording timer (center col) -->
-                <HorizontalStackLayout Grid.Column="1"
+                <!-- Col 1: Sensor overlay settings — data-bars icon -->
+                <Grid Grid.Column="1" WidthRequest="44" HeightRequest="44" Margin="4,0,0,0">
+                    <Border StrokeShape="RoundRectangle 22"
+                            BackgroundColor="#55000000" Stroke="Transparent"
+                            WidthRequest="44" HeightRequest="44" />
+                    <Path Data="M4,6 h16 v2 h-16 Z M4,11 h10 v2 h-10 Z M4,16 h13 v2 h-13 Z"
+                          Fill="White" Aspect="Uniform"
+                          WidthRequest="20" HeightRequest="20"
+                          HorizontalOptions="Center" VerticalOptions="Center" />
+                    <Grid.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding OpenSettingsCommand}" />
+                    </Grid.GestureRecognizers>
+                </Grid>
+
+                <!-- Col 2: Recording timer (center) -->
+                <HorizontalStackLayout Grid.Column="2"
                                        HorizontalOptions="Center" VerticalOptions="Center"
                                        Spacing="6"
                                        IsVisible="{Binding IsRecording}">
@@ -137,8 +195,8 @@
                            VerticalOptions="Center" />
                 </HorizontalStackLayout>
 
-                <!-- Camera settings gear -->
-                <Border Grid.Column="2"
+                <!-- Col 3: Camera settings gear -->
+                <Border Grid.Column="3"
                         StrokeShape="RoundRectangle 22"
                         BackgroundColor="#55000000" Stroke="Transparent"
                         WidthRequest="44" HeightRequest="44">
@@ -153,35 +211,6 @@
             </Grid>
 
 
-            <!-- ── Zoom pills strip (BindableLayout, dynamic presets) ── -->
-            <Border VerticalOptions="End" HorizontalOptions="Center"
-                    Margin="0,0,0,12"
-                    StrokeShape="RoundRectangle 16" Stroke="Transparent"
-                    BackgroundColor="#66000000" Padding="6,4"
-                    IsVisible="{Binding HasCameraPermission}">
-                <HorizontalStackLayout Spacing="2"
-                    BindableLayout.ItemsSource="{Binding ZoomPresets}">
-                    <BindableLayout.ItemTemplate>
-                        <DataTemplate x:DataType="models:ZoomPreset">
-                            <Border StrokeShape="RoundRectangle 13" Stroke="Transparent"
-                                    MinimumWidthRequest="36" HeightRequest="28"
-                                    Padding="6,0"
-                                    BackgroundColor="{Binding PillBackground}">
-                                <Label Text="{Binding Label}"
-                                       FontSize="{Binding LabelSize}"
-                                       FontAttributes="Bold"
-                                       TextColor="{Binding LabelColor}"
-                                       HorizontalOptions="Center"
-                                       VerticalOptions="Center" />
-                                <Border.GestureRecognizers>
-                                    <TapGestureRecognizer Command="{Binding SelectCommand}" />
-                                </Border.GestureRecognizers>
-                            </Border>
-                        </DataTemplate>
-                    </BindableLayout.ItemTemplate>
-                </HorizontalStackLayout>
-            </Border>
-
         </Grid>
         <!-- ═══ END ROW 0 ═══ -->
 
@@ -192,23 +221,8 @@
         <VerticalStackLayout Grid.Row="1" BackgroundColor="Black"
                              Padding="0,16,0,8" Spacing="12">
 
-            <!-- Sensor-settings icon row (above main controls) -->
-            <HorizontalStackLayout HorizontalOptions="Center" Spacing="0">
-                <Border StrokeShape="RoundRectangle 16"
-                        BackgroundColor="Transparent" Stroke="Transparent"
-                        Padding="12,4">
-                    <Label Text="SENSORS ⚙"
-                           FontSize="11" CharacterSpacing="0.8"
-                           TextColor="#8E8E93"
-                           HorizontalOptions="Center" />
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding OpenSettingsCommand}" />
-                    </Border.GestureRecognizers>
-                </Border>
-            </HorizontalStackLayout>
-
-            <!-- ── Main controls: thumbnail | shutter | flip ── -->
-            <Grid ColumnDefinitions="*,Auto,*" Padding="24,0" ColumnSpacing="0">
+            <!-- ── Main controls: thumbnail | PHOTO | shutter | VIDEO | flip ── -->
+            <Grid ColumnDefinitions="Auto,*,Auto,*,Auto" Padding="16,0" ColumnSpacing="0">
 
                 <!-- Gallery thumbnail — circular like Samsung reference -->
                 <Border Grid.Column="0"
@@ -216,7 +230,7 @@
                         Stroke="White" StrokeThickness="1.5"
                         WidthRequest="56" HeightRequest="56"
                         BackgroundColor="#1AFFFFFF"
-                        HorizontalOptions="Start" VerticalOptions="Center">
+                        HorizontalOptions="Center" VerticalOptions="Center">
                     <Image Source="{Binding LastCaptureImage}"
                            Aspect="AspectFill"
                            WidthRequest="53" HeightRequest="53" />
@@ -225,9 +239,31 @@
                     </Border.GestureRecognizers>
                 </Border>
 
+                <!-- PHOTO mode toggle — left of shutter -->
+                <VerticalStackLayout Grid.Column="1" Spacing="4"
+                                     HorizontalOptions="Center" VerticalOptions="Center">
+                    <Label Text="PHOTO" FontSize="12" CharacterSpacing="1.5"
+                           FontAttributes="{Binding SelectedMode,
+                               Converter={StaticResource ModeToFontConverter},
+                               ConverterParameter=Photo}"
+                           TextColor="{Binding SelectedMode,
+                               Converter={StaticResource ModeToTextColorConverter},
+                               ConverterParameter=Photo}"
+                           HorizontalOptions="Center">
+                        <Label.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding SetPhotoModeCommand}" />
+                        </Label.GestureRecognizers>
+                    </Label>
+                    <BoxView WidthRequest="5" HeightRequest="5" CornerRadius="2.5"
+                             BackgroundColor="White" HorizontalOptions="Center"
+                             IsVisible="{Binding SelectedMode,
+                                 Converter={StaticResource ModeToVisibilityConverter},
+                                 ConverterParameter=Photo}" />
+                </VerticalStackLayout>
+
                 <!-- ── Shutter button (center) ── Samsung style: big ring + fill ── -->
                 <Grid x:Name="ShutterButton"
-                      Grid.Column="1"
+                      Grid.Column="2"
                       WidthRequest="82" HeightRequest="82"
                       HorizontalOptions="Center" VerticalOptions="Center">
 
@@ -260,48 +296,9 @@
                     </Grid.GestureRecognizers>
                 </Grid>
 
-                <!-- Camera flip — circular Samsung-style -->
-                <Grid Grid.Column="2"
-                      WidthRequest="56" HeightRequest="56"
-                      HorizontalOptions="End" VerticalOptions="Center">
-                    <Border StrokeShape="RoundRectangle 28"
-                            BackgroundColor="#33FFFFFF" Stroke="Transparent"
-                            WidthRequest="56" HeightRequest="56" />
-                    <Path Data="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 16c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 9.74C4.46 10.97 4 12.43 4 14c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
-                          Fill="White" Aspect="Uniform"
-                          WidthRequest="28" HeightRequest="28"
-                          HorizontalOptions="Center" VerticalOptions="Center" />
-                    <Grid.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding ToggleCameraCommand}" />
-                    </Grid.GestureRecognizers>
-                </Grid>
-
-            </Grid>
-
-            <!-- ── Mode selector ── -->
-            <HorizontalStackLayout HorizontalOptions="Center" Spacing="32">
-
-                <VerticalStackLayout Spacing="4" HorizontalOptions="Center">
-                    <Label Text="PHOTO" FontSize="12" CharacterSpacing="1.5"
-                           FontAttributes="{Binding SelectedMode,
-                               Converter={StaticResource ModeToFontConverter},
-                               ConverterParameter=Photo}"
-                           TextColor="{Binding SelectedMode,
-                               Converter={StaticResource ModeToTextColorConverter},
-                               ConverterParameter=Photo}"
-                           HorizontalOptions="Center">
-                        <Label.GestureRecognizers>
-                            <TapGestureRecognizer Command="{Binding SetPhotoModeCommand}" />
-                        </Label.GestureRecognizers>
-                    </Label>
-                    <BoxView WidthRequest="5" HeightRequest="5" CornerRadius="2.5"
-                             BackgroundColor="White" HorizontalOptions="Center"
-                             IsVisible="{Binding SelectedMode,
-                                 Converter={StaticResource ModeToVisibilityConverter},
-                                 ConverterParameter=Photo}" />
-                </VerticalStackLayout>
-
-                <VerticalStackLayout Spacing="4" HorizontalOptions="Center">
+                <!-- VIDEO mode toggle — right of shutter -->
+                <VerticalStackLayout Grid.Column="3" Spacing="4"
+                                     HorizontalOptions="Center" VerticalOptions="Center">
                     <Label Text="VIDEO" FontSize="12" CharacterSpacing="1.5"
                            FontAttributes="{Binding SelectedMode,
                                Converter={StaticResource ModeToFontConverter},
@@ -321,7 +318,23 @@
                                  ConverterParameter=Video}" />
                 </VerticalStackLayout>
 
-            </HorizontalStackLayout>
+                <!-- Camera flip — circular Samsung-style -->
+                <Grid Grid.Column="4"
+                      WidthRequest="56" HeightRequest="56"
+                      HorizontalOptions="Center" VerticalOptions="Center">
+                    <Border StrokeShape="RoundRectangle 28"
+                            BackgroundColor="#33FFFFFF" Stroke="Transparent"
+                            WidthRequest="56" HeightRequest="56" />
+                    <Path Data="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 16c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 9.74C4.46 10.97 4 12.43 4 14c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
+                          Fill="White" Aspect="Uniform"
+                          WidthRequest="28" HeightRequest="28"
+                          HorizontalOptions="Center" VerticalOptions="Center" />
+                    <Grid.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding ToggleCameraCommand}" />
+                    </Grid.GestureRecognizers>
+                </Grid>
+
+            </Grid>
 
         </VerticalStackLayout>
         <!-- ═══ END ROW 1 ═══ -->

--- a/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml.cs
+++ b/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml.cs
@@ -75,6 +75,13 @@ namespace TravelCamApp.Views
                 System.Diagnostics.Debug.WriteLine("[MainPage] CameraReady event received, calling OnCameraReady()");
                 OnCameraReady();
             };
+
+            // ── Aspect ratio changes → recompute letterbox bars ──────────────
+            _cameraSettingsVm.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(TravelCamApp.ViewModels.CameraSettingsViewModel.SelectedAspectRatio))
+                    UpdateAspectRatioBars(CameraView.Width, CameraView.Height);
+            };
         }
 
         // ── Lifecycle ──────────────────────────────────────────────────────────
@@ -136,134 +143,123 @@ namespace TravelCamApp.Views
         public void OnCameraReady()
         {
             System.Diagnostics.Debug.WriteLine("[MainPage] OnCameraReady called");
-
-            if (CameraView == null)
-            {
-                System.Diagnostics.Debug.WriteLine("[MainPage] OnCameraReady: CameraView is null");
-                return;
-            }
-
-            CalculateAndPositionCameraViewChildrenContainer(
-                CameraView.Width,
-                CameraView.Height,
-                CameraView.SelectedCamera);
+            if (CameraView == null) return;
+            ApplyCameraLayout(CameraView.Width, CameraView.Height, CameraView.SelectedCamera);
         }
 
         // ── Camera view alignment ──────────────────────────────────────────────────
 
-        /// <summary>
-        /// Event handler called when CameraView size changes or camera is selected.
-        /// Recalculates CameraViewChildrenContainer to align with visible camera feed.
-        /// </summary>
         private void OnCameraViewSizeChanged(object? sender, EventArgs e)
         {
             if (sender is not CameraView cameraView) return;
+            try { ApplyCameraLayout(cameraView.Width, cameraView.Height, cameraView.SelectedCamera); }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[MainPage] OnCameraViewSizeChanged error: {ex.Message}"); }
+        }
 
-            try
-            {
-                CalculateAndPositionCameraViewChildrenContainer(
-                    cameraView.Width,
-                    cameraView.Height,
-                    cameraView.SelectedCamera);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine(
-                    $"[MainPage] OnCameraViewSizeChanged error: {ex.Message}");
-            }
+        // Called when aspect ratio setting changes — recalculate without a new camera size event.
+        private void UpdateAspectRatioBars(double _w, double _h)
+        {
+            if (CameraView != null)
+                ApplyCameraLayout(CameraView.Width, CameraView.Height, CameraView.SelectedCamera);
         }
 
         /// <summary>
-        /// Calculates the visible camera feed bounds (accounting for AspectFit letterboxing/pillarboxing)
-        /// and sizes/positions CameraViewChildrenContainer to match.
+        /// Single unified method that:
+        ///   1. Calculates the natural visible container size (AspectFit of camera native resolution)
+        ///   2. Applies the selected aspect ratio crop:
+        ///      - "Full"  → no additional crop (container = natural size)
+        ///      - "4:3"   → portrait preview h/w = 4/3  (landscape 4:3 output, portrait shows 3:4)
+        ///      - "16:9"  → portrait preview h/w = 9/16 (landscape 16:9 output, preview is a horizontal band)
+        ///      - "1:1"   → portrait preview h/w = 1
+        ///   3. Sets CameraViewChildrenContainer to the cropped size
+        ///   4. Updates ViewModel bar heights so the black overlay bars cover the cropped-away areas
         ///
-        /// Logic:
-        /// 1. Get camera view dimensions and selected camera resolution
-        /// 2. Handle orientation by swapping resolution dimensions for portrait
-        /// 3. Calculate aspect ratios (camera vs viewport)
-        /// 4. Determine visible dimensions based on AspectFit scaling
-        /// 5. Set CameraViewChildrenContainer size
-        /// 6. HorizontalOptions/VerticalOptions="Center" automatically centers it
+        /// Bar heights are computed from the CameraView height so bars reach from
+        /// the Row 0 edges all the way to the (possibly already AspectFit-letterboxed)
+        /// container edges.
         /// </summary>
-        private void CalculateAndPositionCameraViewChildrenContainer(
-            double cameraViewWidth,
-            double cameraViewHeight,
-            CameraInfo? selectedCamera)
+        private void ApplyCameraLayout(double cameraViewWidth, double cameraViewHeight, CameraInfo? selectedCamera)
         {
-            // 1. SAFETY CHECKS
-            if (cameraViewWidth <= 0 || cameraViewHeight <= 0)
-            {
-                System.Diagnostics.Debug.WriteLine(
-                    "[MainPage] CameraView has invalid dimensions, skipping container calculation");
-                return;
-            }
-
-            if (selectedCamera == null)
-            {
-                System.Diagnostics.Debug.WriteLine(
-                    "[MainPage] No camera selected, skipping container calculation");
-                return;
-            }
-
-            if (selectedCamera.SupportedResolutions == null || selectedCamera.SupportedResolutions.Count == 0)
-            {
-                System.Diagnostics.Debug.WriteLine(
-                    "[MainPage] Camera has no supported resolutions, skipping container calculation");
-                return;
-            }
-
-            if (CameraViewChildrenContainer == null)
-            {
-                System.Diagnostics.Debug.WriteLine(
-                    "[MainPage] CameraViewChildrenContainer not found, skipping calculation");
-                return;
-            }
+            if (cameraViewWidth <= 0 || cameraViewHeight <= 0) return;
+            if (selectedCamera == null) return;
+            if (selectedCamera.SupportedResolutions == null || selectedCamera.SupportedResolutions.Count == 0) return;
+            if (CameraViewChildrenContainer == null) return;
 
             try
             {
-                // 2. GET CAMERA RESOLUTION
-                // Use highest resolution (most likely what's being rendered)
-                var cameraResolution = selectedCamera.SupportedResolutions[selectedCamera.SupportedResolutions.Count - 1];
-                double cameraWidth = cameraResolution.Width;
-                double cameraHeight = cameraResolution.Height;
+                // ── Step 1: natural visible area (AspectFit of sensor resolution) ──────────
+                var res = selectedCamera.SupportedResolutions[selectedCamera.SupportedResolutions.Count - 1];
+                double camW = res.Width;
+                double camH = res.Height;
 
-                // 3. HANDLE ORIENTATION
-                // Device is in portrait, so swap camera dimensions to match portrait coordinate system
                 var displayInfo = DeviceDisplay.Current.MainDisplayInfo;
                 if (displayInfo.Orientation == DisplayOrientation.Portrait)
-                {
-                    (cameraWidth, cameraHeight) = (cameraHeight, cameraWidth);
-                }
+                    (camW, camH) = (camH, camW);
 
-                // 4. CALCULATE ASPECT RATIOS
-                double cameraAspect = cameraWidth / cameraHeight;
+                double camAspect  = camW / camH;
                 double viewAspect = cameraViewWidth / cameraViewHeight;
 
-                // 5. CALCULATE VISIBLE DIMENSIONS (with AspectFit scaling)
-                double visibleWidth, visibleHeight;
-
-                if (cameraAspect > viewAspect)
+                double naturalW, naturalH;
+                if (camAspect > viewAspect)
                 {
-                    // Camera is wider relative to view → letterbox top/bottom
-                    visibleWidth = cameraViewWidth;
-                    visibleHeight = cameraViewWidth / cameraAspect;
+                    naturalW = cameraViewWidth;
+                    naturalH = cameraViewWidth / camAspect;
                 }
                 else
                 {
-                    // Camera is taller relative to view → pillarbox left/right
-                    visibleHeight = cameraViewHeight;
-                    visibleWidth = cameraViewHeight * cameraAspect;
+                    naturalH = cameraViewHeight;
+                    naturalW = cameraViewHeight * camAspect;
                 }
 
-                // 6. SET CONTAINER SIZE
-                // HorizontalOptions="Center" and VerticalOptions="Center" automatically center it
-                CameraViewChildrenContainer.WidthRequest = visibleWidth;
-                CameraViewChildrenContainer.HeightRequest = visibleHeight;
+                // ── Step 2: apply aspect ratio crop ─────────────────────────────────────────
+                // The labels (4:3, 16:9, 1:1) refer to LANDSCAPE output ratios.
+                // In portrait preview the height-to-width ratio is the INVERSE:
+                //   • 4:3  landscape → portrait h/w = 4/3  (tall-ish, ~same as native on most cameras)
+                //   • 16:9 landscape → portrait h/w = 9/16 (horizontal band — crops top/bottom heavily)
+                //   • 1:1            → portrait h/w = 1/1  (square)
+                var ratio = _cameraSettingsVm.SelectedAspectRatio;
+                double r = ratio switch
+                {
+                    TravelCamApp.ViewModels.AspectRatioOption.FourThree   => 4.0 / 3.0,
+                    TravelCamApp.ViewModels.AspectRatioOption.SixteenNine => 9.0 / 16.0,   // portrait h/w for 16:9 output
+                    TravelCamApp.ViewModels.AspectRatioOption.OneOne       => 1.0,
+                    _                                                       => 0.0           // FullScreen
+                };
+
+                double croppedH;
+                if (r > 0)
+                {
+                    double desiredH = naturalW * r;
+                    croppedH = desiredH < naturalH ? desiredH : naturalH; // can't show more than natural
+                }
+                else
+                {
+                    croppedH = naturalH;
+                }
+
+                // ── Step 3: resize container to the cropped area ─────────────────────────────
+                CameraViewChildrenContainer.WidthRequest  = naturalW;
+                CameraViewChildrenContainer.HeightRequest = croppedH;
+
+                // ── Step 4: bar heights cover from Row-0 edge to container edge ──────────────
+                // Container is centered vertically in the CameraView (VerticalOptions="Center").
+                // Bars must reach from the CameraView top/bottom to the container top/bottom.
+                bool hasBars = r > 0 && croppedH < naturalH;
+                if (hasBars)
+                {
+                    double barH = (cameraViewHeight - croppedH) / 2.0;
+                    ViewModel.AspectTopBarHeight    = barH;
+                    ViewModel.AspectBottomBarHeight = barH;
+                }
+                else
+                {
+                    ViewModel.AspectTopBarHeight    = 0;
+                    ViewModel.AspectBottomBarHeight = 0;
+                }
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine(
-                    $"[MainPage] CalculateAndPositionCameraViewChildrenContainer error: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"[MainPage] ApplyCameraLayout error: {ex.Message}");
             }
         }
 


### PR DESCRIPTION
- Moved zoom pills strip from bottom to top center of camera feed
- Redesigned main controls row to include PHOTO/VIDEO mode toggles
- Integrated mode selection into main controls, removed separate selector
- Adjusted camera flip button position and control alignments for new layout

Add aspect ratio crop overlay and UI refinements

- Implement user-selectable aspect ratio crop (Full, 4:3, 16:9, 1:1) for camera preview with black bar overlays
- Add aspect ratio selector to settings panel with visual feedback
- Update ViewModel to persist and react to aspect ratio changes
- Refactor camera preview layout logic for accurate cropping
- Show zoom preset strip only on devices with multiple cameras
- Move sensor overlay settings icon to top toolbar
- Merge mode selector (PHOTO/VIDEO) into main control row
- Switch sensor overlay to BindableLayout for better sizing
- Update developer URL and allowed web fetch domains