### PR TITLE
Move EXIF/crop I/O to background thread; add info read guard

### DIFF
--- a/Projects/TravelCam/CLAUDE.md
+++ b/Projects/TravelCam/CLAUDE.md
@@ -244,6 +244,9 @@ See `CodeStyle.txt` for full standards. Key rules:
 | `ImageViewerView.xaml` | Full-screen gallery viewer with carousel + thumbnail strip |
 | `ImageViewerView.xaml.cs` | Gallery navigation, sharing, delete operations |
 | `FilePathToImageSourceConverter.cs` | Converts file paths to `ImageSource` using `FromStream()` for reliable loading from app cache |
+| `Models/PhotoCaptureMetadata.cs` | Snapshot of sensor data collected at capture time — written into JPEG EXIF |
+| `Models/MediaInfo.cs` | EXIF metadata read back from a captured file — displayed in gallery info panel |
+| `Platforms/Android/ExifHelper.cs` | Android-only JPEG EXIF read/write. `ApplyMetadata` writes tags; `ReadMetadata` returns `MediaInfo` |
 
 ---
 
@@ -324,130 +327,161 @@ Key compile checks:
 
 ---
 
-## RECENT FIXES (2026-04-15)
+## RECENT FIXES (2026-04-16)
 
-### 1. Aspect Ratio Crop Bugs — 3-Part Fix
-**Files:** `MainPageViewModel.cs`, `MainPage.xaml.cs`, `MainPage.xaml`
+### 1. Sensor Overlay + Settings Panel in ImageViewerView (Gallery)
+**Files:** `Views/ImageViewerView.xaml`, `Views/ImageViewerView.xaml.cs`, `Views/MainPage.xaml`, `Views/MainPage.xaml.cs`, `ViewModels/MainPageViewModel.cs`
 
-**Bug A — 1:1 image rotated 90° in gallery:**
-- `BitmapFactory.DecodeStream` ignores EXIF orientation → decoded bitmap is always landscape pixels
-- Fix: buffer input → write to temp file → read `ExifInterface.TagOrientation` → rotate bitmap via `Matrix.PostRotate()` → crop using **portrait-convention ratios** (3:4=`3.0/4.0`, 9:16=`9.0/16.0`, 1:1=`1.0`) on the upright bitmap → save without EXIF (pixels already correct)
+- `DataOverlayView` (sensor pill) added to gallery — positioned at bottom-right of the **actual displayed image**, not the container. Margin is computed at runtime via `UpdateOverlayPosition()`.
+- `OverlaySettingsView` added to gallery — same settings panel as camera view, shared `OverlaySettingsViewModel` instance.
+- `IsGallerySettingsVisible` added to `MainPageViewModel` — dedicated flag for gallery settings overlay, independent of camera's `IsSettingsVisible`.
+- `OpenSettingsCommand` is now context-aware: sets `IsGallerySettingsVisible` when gallery is open, `IsSettingsVisible` otherwise.
+- Wired from `MainPage.xaml.cs` via `GalleryView.WireSensorSettings(_sensorSettingsVm, viewModel)`.
 
-**Bug B — 16:9 mode shows a landscape band in portrait:**
-- `SixteenNine => 9.0/16.0` gave `r = 0.5625` → `croppedH = naturalW × 0.5625` → container width > height → landscape crop indicator
-- Fix: `isPortrait ? 16.0/9.0 : 9.0/16.0` (orientation-aware). Now shows a tall portrait 9:16 crop frame.
+**⚠️ Critical pattern: BindingContext override breaks compiled XAML bindings.**
+`WireSensorSettings` sets `SensorSettingsOverlay.BindingContext = OverlaySettingsViewModel`.
+Any `{Binding IsGallerySettingsVisible}` on that element is compiled against `MainPageViewModel` but runtime context becomes `OverlaySettingsViewModel` → binding mismatch → overlay stuck.
+**Fix:** `IsVisible="False"` in XAML; drive from code via `mainVm.PropertyChanged` subscription in `WireSensorSettings`.
 
-**Bug C — 3:4 and 9:16 look the same on 4:3 sensor devices:**
-- With `r = 16/9`, `croppedH = naturalW × 1.778 > naturalH` on 4:3 sensors → clamped to naturalH → same as Full
-- Fix: Added **pillarbox** (left/right bar) support. When `desiredH > naturalH`: `croppedW = naturalH / r` and `croppedH = naturalH`. New properties `AspectLeftBarWidth`, `AspectRightBarWidth`, `HasAspectSideBars` added to `MainPageViewModel`. Two new `BoxView` bars at `HorizontalOptions="Start/End"` added to `MainPage.xaml`.
-- Also fixed resolution normalization: `camLong = Math.Max(res.Width, res.Height)` → robust to both portrait/landscape resolution reporting from toolkit.
+### 2. Overlay Position Respects EXIF Orientation
+**File:** `Views/ImageViewerView.xaml.cs` — `UpdateOverlayPosition()`
 
-### 2. Gallery Crash (SelectionChanged re-entrancy) — Fixed
-**File:** `ImageViewerView.xaml.cs`
+`BitmapFactory.DecodeFile` with `InJustDecodeBounds` returns raw stored dimensions, ignoring EXIF rotation. A portrait photo stored landscape (e.g. 4000×3000, Orientation=6) gives aspect 1.33 instead of 0.75 → wrong margin → pill lands in black bars.
+**Fix:** After `DecodeFile`, read `ExifInterface.TagOrientation`; if orientation ≥ 5 (values 5–8 = any 90°/270° rotation), swap imageW and imageH before aspect ratio math.
 
-**Root causes:**
-1. `OpenImageViewer()` sets `GalleryImagePaths` and `CurrentImageIndex` **before** `IsImageViewerVisible = true`. Property change notifications fire `SelectionChanged` → `OnThumbnailSelected` calls `MainCarousel.ScrollTo()` on a non-rendered CarouselView → crash.
-2. Inside `OnThumbnailSelected`, setting `vm.CurrentImageIndex` notifies `CurrentImageItem` → TwoWay `SelectedItem` binding updates CollectionView → fires `SelectionChanged` again → re-entrant double `ScrollTo`.
+```csharp
+using var exif = new Android.Media.ExifInterface(filePath);
+int orientation = exif.GetAttributeInt(Android.Media.ExifInterface.TagOrientation,
+    (int)Android.Media.Orientation.Normal);
+if (orientation >= 5)
+    (imageW, imageH) = (imageH, imageW);
+```
 
-**Fix:**
-- Added `_isSyncingThumbnail` bool flag — blocks re-entrant calls while processing a tap
-- Added `if (!IsVisible)` guard — discards all binding-driven events when gallery panel is hidden
-- Wrapped `MainCarousel.ScrollTo` in try/catch
+### 3. Gallery Crash on Rapid Thumbnail Taps — Fixed
+**File:** `Views/ImageViewerView.xaml.cs` — `OnCarouselPositionChanged`
 
-### 3. Camera Layout Refactor
-**File:** `MainPage.xaml`
+`async void` + debounce: `_scrollDebounceCancel.Cancel()` caused previous `await Task.Delay(..., token)` to throw `OperationCanceledException` with no handler → unhandled exception on UI thread → **crash**.
+**Fix:** Added `catch (OperationCanceledException)` — expected cancellation, silently ignored.
+Moved `StopSharedVideoPlayer()`, `IsMediaInfoVisible=false`, and `UpdateOverlayPosition()` inside the `try` block so they only run when debounce settles.
 
-- **Removed** the 4-column top toolbar `[Flash] [Sensor] [timer] [Camera Settings]`
-- **Moved** all three icon buttons **inside** `CameraViewChildrenContainer` as a right-side `VerticalStackLayout` at `HorizontalOptions="End" VerticalOptions="Start" Margin="0,12,12,0"`:
-  - Top: Camera Settings (gear)
-  - Middle: Flash Toggle (yellow bolt / white slash)
-  - Bottom: Sensor Overlay Settings (data bars)
-- **Kept** recording timer as a standalone `HorizontalStackLayout` at `VerticalOptions="Start" HorizontalOptions="Center"` — only visible when `IsRecording`
+**Rule:** Any `async void` using debounce cancellation MUST catch `OperationCanceledException`.
+
+### 4. Camera Container Layout — Always Uses Native Resolution
+**File:** `Views/MainPage.xaml.cs` — `ApplyCameraLayout()`
+
+`CameraViewChildrenContainer` was sized using the user-selected capture resolution instead of the camera's native (largest) resolution. The live preview always streams the full sensor feed at its native aspect ratio, so the capture resolution setting must not affect the layout.
+**Fix:** Always use `SupportedResolutions.OrderByDescending(pixel count).First()` for the layout calculation.
 
 ---
 
-## RECENT CRITICAL FIXES (2026-04-12)
+## RECENT FIXES (2026-04-15)
 
-> **📖 COMPLETE SOLUTION:** All fixes consolidated in master memory file:  
-> **`~/.claude/projects/[...]/memory/MASTER-XAML-AND-LIFECYCLE-CRASH-FIX-2026-04-12.md`**  
-> This single document contains all 5 parts with code, diagnostic flowchart, and is reusable for other MAUI apps.
+### 1. EXIF Metadata Write on Photo Capture
+**Files:** `Platforms/Android/ExifHelper.cs` (new), `Models/PhotoCaptureMetadata.cs` (new), `MainPageViewModel.cs`
 
-### Camera Reopen Crash — 5-Part Complete Solution
-**Status:** ✅ IMPLEMENTED & VERIFIED (Build: 0 errors, 0 warnings)
-**Tested:** Real Android devices, multiple reopen cycles
+- `BuildPhotoCaptureMetadata()` snapshots current sensor state (GPS, temperature, heading, speed, city, country, flash, aspect ratio, resolution) into a `PhotoCaptureMetadata` at capture time.
+- `ExifHelper.ApplyMetadata(stream, meta)` writes all standard EXIF tags (GPS, date, device, flash) plus a `JSON:` prefixed `UserComment` payload for custom fields.
+- **⚠️ Heavy I/O — must be on background thread.** Both `CropStreamToAspectRatio` and `ApplyMetadata` are combined in a single `await Task.Run(...)` inside `OnMediaCaptured`. Never call these on the main thread.
 
-**Problem:** App crashes when reopened after being closed (swipe away from recents)
-**Confirmed on:** Real Android smartphones (not just emulator)
-**Root Cause:** Known .NET 10 regression — ObjectDisposedException on IServiceProvider (fixed in SR5)
+### 2. Gallery Info Panel ("i" button)
+**Files:** `Models/MediaInfo.cs` (new), `MainPageViewModel.cs`, `Views/ImageViewerView.xaml`
 
-**Solution:** Proper Window.Stopped/Window.Destroying lifecycle cleanup in App.xaml.cs
+- `ToggleMediaInfoCommand` shows/hides an info overlay on the current gallery image.
+- `ExifHelper.ReadMetadata(path)` reads tags back and populates a `MediaInfo` object — also wrapped in `await Task.Run(...)` (disk I/O on tap).
+- `_isLoadingMediaInfo` guard prevents double-tap launching concurrent reads.
+- `MediaInfo` exposes computed `HasCameraInfo`, `HasLocationInfo`, `HasConditionsInfo` for section visibility.
 
-**Root Causes & Solutions:**
+### 3. Gallery Delete-then-Click Crash — Fixed
+**File:** `MainPageViewModel.cs`
 
-1. **Inverted initialization flag** (Commit e8540aa)
-   - Changed `_isAppInitialized = true` → `_isAppInitialized = false`
-   - Set to `true` only after `InitializeAsync` completes
-   - Reset to `false` in `OnWindowDestroying`
-   - **File:** `MainPageViewModel.cs` (line 94, 388-389, 716)
+- After deleting the last item, `GalleryImagePaths` becomes empty → `CurrentImageIndex` clamp + null check guards prevent indexing into an empty list → no crash.
 
-2. **UI-blocking wait loop** (Commit 3baf19f)
-   - Removed `while (!_isAppInitialized)` loop that blocked OnAppearing
-   - OnViewReady now returns immediately, lets InitializeAsync work asynchronously
-   - **File:** `MainPageViewModel.cs` (lines 750-779, 393-398)
+### 4. Main Thread Freeze — Fixed
+**File:** `MainPageViewModel.cs`
 
-3. **Android linker stripping CameraView in Release mode** (Current)
-   - Created `linker.xml` to preserve all CommunityToolkit.Maui.Camera types
-   - Added `<AndroidLinkDescription Include="linker.xml" />` to .csproj
-   - **Files:** `linker.xml` (new), `TravelCamApp.csproj` (updated)
+- `ExifInterface` write + re-read (~500–2000 ms) and bitmap decode/rotate were running on the main thread → ANR/freeze.
+- Fix: single `await Task.Run(...)` wrapping both `CropStreamToAspectRatio` + `ExifHelper.ApplyMetadata` in `OnMediaCaptured`; separate `await Task.Run(...)` for `ExifHelper.ReadMetadata` in `ExecuteToggleMediaInfo`.
 
-4. **Failed resource cleanup on page disappear** (Current)
-   - Added `OnDisappearing()` handler to explicitly stop camera preview
-   - Ensures CameraView resources released before page destroyed
-   - **File:** `MainPage.xaml.cs` (+30 lines)
+### 5. Aspect Ratio Crop Bugs — 3-Part Fix
+**Files:** `MainPageViewModel.cs`, `MainPage.xaml.cs`, `MainPage.xaml`
 
-5. **Camera operations conflicting with Android lifecycle** (Current)
-   - Wrapped 9 CameraHelper methods in `MainThread.BeginInvokeOnMainThread()`
-   - Methods: SelectFirstAvailableCamera, ToggleCamera, StartPreview, StopPreview, TriggerCapture, StartVideoRecording, StopVideoRecording, CycleFlashMode, SetZoom
-   - **File:** `CameraHelper.cs` (9 methods updated)
+- **Bug A (1:1 rotated 90°):** `BitmapFactory.DecodeStream` ignores EXIF orientation. Fix: buffer → temp file → read `TagOrientation` → `Matrix.PostRotate()` → crop upright bitmap.
+- **Bug B (16:9 landscape band in portrait):** `SixteenNine => 9.0/16.0` gave `r = 0.5625` → landscape crop. Fix: `isPortrait ? 16.0/9.0 : 9.0/16.0`.
+- **Bug C (3:4 = 9:16 on 4:3 sensors):** `desiredH > naturalH` was clamped. Fix: pillarbox bars (`AspectLeftBarWidth`, `AspectRightBarWidth`, `HasAspectSideBars` + two `BoxView` in XAML).
 
-**Temporary Workaround:**
-- Disabled custom font loading in `MauiProgram.cs` (font assets not deploying to APK)
-- App uses system sans-serif fonts
-- TODO: Fix proper font asset deployment and re-enable custom fonts
+### 6. Gallery Crash (SelectionChanged re-entrancy) — Fixed
+**File:** `ImageViewerView.xaml.cs`
 
-**Testing Checklist:**
-- [ ] First launch: App opens, camera preview appears
-- [ ] Background/return: Smooth camera resume without black screen
-- [ ] Close/reopen 10x: Zero crashes, consistent 60fps rendering
-- [ ] Release build: Linker.xml prevents stripping, app starts correctly
-- [ ] Resource cleanup: No "A resource failed" warnings in logcat
+- `_isSyncingThumbnail` bool flag blocks re-entrant calls; `if (!IsVisible)` guard discards binding-driven events when gallery panel is hidden.
 
-**6. XAML Parse Errors** (Final Session)
-   - Removed invalid `SafeAreaEdges="Top/Bottom/None"` attributes from XAML
-   - MAUI type converter cannot parse enum string values — use explicit padding instead
-   - **Files:** `MainPage.xaml` (lines 13, 74, 170)
+### 7. Camera Layout Refactor
+**File:** `MainPage.xaml`
 
-**Memory Reference (Complete):** See master memory file noted above — contains all 5-6 parts with full technical details, diagnostic flowchart, and reusable patterns for other MAUI apps.
+- Top toolbar removed; Flash, Sensor, Camera Settings moved inside `CameraViewChildrenContainer` as right-edge `VerticalStackLayout`. Recording timer remains centered, visible only when `IsRecording`.
+
+---
+
+## CRITICAL PATTERNS
+
+### Heavy I/O Must Run on Background Thread
+`ExifInterface`, `BitmapFactory.DecodeStream`, file writes — all block for 500–2000 ms on mobile. **Always wrap in `await Task.Run()`.**
+
+```csharp
+// Capture — crop + EXIF write in one hop
+stream = await Task.Run(() =>
+{
+    var cropped = CropStreamToAspectRatio(inStream, ratio);
+    return (Stream)ExifHelper.ApplyMetadata(cropped, meta);
+});
+
+// Info tap — EXIF read
+var info = await Task.Run(() => ExifHelper.ReadMetadata(path));
+```
+
+Use a guard bool (`_isLoadingMediaInfo`) to prevent double-tap launching concurrent reads.
+
+---
+
+## PRIOR FIXES (2026-04-12) — Camera Reopen Crash
+
+> **Complete solution in master memory file:**
+> `~/.claude/projects/[...]/memory/MASTER-XAML-AND-LIFECYCLE-CRASH-FIX-2026-04-12.md`
+
+**Status:** ✅ Implemented & tested on real Android devices.
+
+Summary of 5-part fix:
+1. Inverted `_isAppInitialized` flag (false by default, set true after init)
+2. Removed `while (!_isAppInitialized)` wait loop from `OnViewReady`
+3. `linker.xml` preserving CommunityToolkit.Maui.Camera types from Release linker
+4. `OnDisappearing()` stops camera preview to release CameraView resources
+5. 9 `CameraHelper` methods wrapped in `MainThread.BeginInvokeOnMainThread()`
+6. Removed invalid `SafeAreaEdges="..."` XAML attributes
+
+**Temporary workaround:** Custom fonts disabled in `MauiProgram.cs` (font assets not deploying to APK). App uses system sans-serif. TODO: fix font deployment.
 
 ---
 
 ## TODO / INCOMPLETE FEATURES
 
-- [ ] **Test camera + video recording on physical Android device** (NEXT: Test all scenarios from checklist above)
-- [ ] **Fix font asset deployment** — currently disabled to allow app startup; re-enable when fixed
+- [ ] **Test camera + video recording on physical Android device**
+- [ ] **Fix font asset deployment** — currently disabled; app uses system fonts
 - [ ] **Test Release build** — verify linker.xml prevents code stripping
 - [ ] Map overlay — not implemented yet
 - [ ] Weather API verification — Open-Meteo integrated, untested on device
 - [ ] Upgrade Target SDK to API 36 before Aug 2026 Google Play deadline
 - [ ] Verify CommunityToolkit.Maui.Camera 6.0.1+ compatibility; check for upgrades
 - [ ] iOS support — scaffold only, not targeted
-- [x] **Gallery stability** — Fixed SelectionChanged re-entrancy crash + hidden-view ScrollTo crash (2026-04-15)
-- [x] **Aspect ratio crop** — EXIF rotation applied, 16:9 portrait preview fixed, pillarbox bars added (2026-04-15)
-- [x] **Camera layout** — Flash, Sensor, Camera Settings moved inside CameraViewChildrenContainer right column (2026-04-15)
+- [x] **EXIF metadata write** — GPS, date, device, flash + JSON UserComment payload written on every capture (2026-04-15)
+- [x] **Gallery info panel** — "i" button shows EXIF data overlay; async `ReadMetadata` with guard (2026-04-15)
+- [x] **Gallery delete crash** — empty list guard after deleting last item (2026-04-15)
+- [x] **Main thread freeze** — crop + EXIF write and EXIF read both moved to `Task.Run` (2026-04-15)
+- [x] **Gallery stability** — SelectionChanged re-entrancy crash + hidden-view ScrollTo crash (2026-04-15); rapid thumbnail tap crash via OperationCanceledException in async void (2026-04-16)
+- [x] **Aspect ratio crop** — EXIF rotation, 16:9 portrait preview, pillarbox bars (2026-04-15)
+- [x] **Camera layout** — Flash, Sensor, Camera Settings inside CameraViewChildrenContainer right column (2026-04-15); container sized from native resolution not capture resolution (2026-04-16)
+- [x] **Gallery sensor overlay** — DataOverlayView pill + OverlaySettingsView in ImageViewerView; position computed from EXIF-corrected aspect ratio (2026-04-16)
 - [x] Flash control — icon path, yellow when on / slash when off
 - [x] Zoom control — 5 preset pills (.6×, 1×, 2, 3, 10) overlaying bottom of preview
 - [x] Migrated from Camera.MAUI 1.5.1 to CommunityToolkit.Maui.Camera 6.0.1
 - [x] DataOverlayViewModel rewired — subscribes to SensorHelper, owns OverlayItems
 - [x] Premium Samsung-style camera UI — shutter ring+circle, flip path icon, grid lines, mode dots
-- [x] Shutter button — vector white ring + white circle
-- [x] Camera reopen crash fixed — 4-part solution (init flag, UI-blocking wait, linker, resource cleanup)
+- [x] Camera reopen crash — 5-part fix (init flag, wait loop, linker, cleanup, MainThread wrapping)

--- a/Projects/TravelCam/TravelCamApp/Helpers/CameraHelper.cs
+++ b/Projects/TravelCam/TravelCamApp/Helpers/CameraHelper.cs
@@ -245,7 +245,6 @@ namespace TravelCamApp.Helpers
                 LogDebug("[CameraHelper] Starting video recording on camera: {0}", cameraView.SelectedCamera.Name);
 
                 // ✅ Start recording on MainThread to prevent lifecycle conflicts
-                bool success = false;
                 var tcs = new TaskCompletionSource<bool>();
 
                 MainThread.BeginInvokeOnMainThread(async () =>

--- a/Projects/TravelCam/TravelCamApp/ViewModels/MainPageViewModel.cs
+++ b/Projects/TravelCam/TravelCamApp/ViewModels/MainPageViewModel.cs
@@ -59,6 +59,7 @@ namespace TravelCamApp.ViewModels
         // Overlay visibility
         private bool _isSensorOverlayVisible = true;
         private bool _isSettingsVisible;
+        private bool _isGallerySettingsVisible;
         private bool _isCameraSettingsVisible;
         private bool _isImageViewerVisible;
 
@@ -83,6 +84,8 @@ namespace TravelCamApp.ViewModels
         private int _currentImageIndex;
         private bool _isMediaInfoVisible;
         private Models.MediaInfo _currentMediaInfo = new();
+        private ObservableCollection<Models.OverlayItem> _galleryOverlayItems = new();
+        private bool _isGalleryOverlayVisible;
 
         // Lifecycle guards — instance-level only (no static flag)
         private List<Window> _trackedWindows = new();  // track all windows for proper cleanup
@@ -186,6 +189,13 @@ namespace TravelCamApp.ViewModels
             set { _isSettingsVisible = value; OnPropertyChanged(); }
         }
 
+        /// <summary>Controls the sensor settings overlay inside the gallery (ImageViewerView).</summary>
+        public bool IsGallerySettingsVisible
+        {
+            get => _isGallerySettingsVisible;
+            set { _isGallerySettingsVisible = value; OnPropertyChanged(); }
+        }
+
         public bool IsCameraSettingsVisible
         {
             get => _isCameraSettingsVisible;
@@ -210,6 +220,20 @@ namespace TravelCamApp.ViewModels
         {
             get => _currentMediaInfo;
             private set { _currentMediaInfo = value; OnPropertyChanged(); }
+        }
+
+        /// <summary>Overlay items populated from the current gallery image's EXIF metadata.</summary>
+        public ObservableCollection<Models.OverlayItem> GalleryOverlayItems
+        {
+            get => _galleryOverlayItems;
+            private set { _galleryOverlayItems = value; OnPropertyChanged(); }
+        }
+
+        /// <summary>True when the gallery sensor pill should be shown (settings enabled + items available).</summary>
+        public bool IsGalleryOverlayVisible
+        {
+            get => _isGalleryOverlayVisible;
+            private set { _isGalleryOverlayVisible = value; OnPropertyChanged(); }
         }
 
         public ObservableCollection<string> GalleryImagePaths
@@ -371,7 +395,13 @@ namespace TravelCamApp.ViewModels
             SetPhotoModeCommand = new Command(() => SelectedMode = CaptureMode.Photo);
             SetVideoModeCommand = new Command(() => SelectedMode = CaptureMode.Video);
             ToggleFlashCommand = new Command(ToggleFlash);
-            OpenSettingsCommand = new Command(() => IsSettingsVisible = true);
+            OpenSettingsCommand = new Command(() =>
+            {
+                if (IsImageViewerVisible)
+                    IsGallerySettingsVisible = true;
+                else
+                    IsSettingsVisible = true;
+            });
             OpenCameraSettingsCommand = new Command(() => IsCameraSettingsVisible = true);
             CloseSettingsCommand = new Command(async () => await SafeExecuteAsync(CloseSettingsAsync));
             OpenGalleryCommand = new Command(() => OpenImageViewer());
@@ -1210,18 +1240,22 @@ namespace TravelCamApp.ViewModels
 
                 var city = GetCityForFileName();
 #if ANDROID
-                stream = CropStreamToAspectRatio(stream, _cameraSettings.SelectedAspectRatio);
-
-                // Embed EXIF metadata (GPS, temperature, device info, etc.) into the JPEG
-                var meta = BuildPhotoCaptureMetadata();
+                // Crop + EXIF write are both heavy sync I/O — run off the main thread
+                var meta      = BuildPhotoCaptureMetadata();
+                var ratio     = _cameraSettings.SelectedAspectRatio;
+                var inStream  = stream;
                 try
                 {
-                    stream = Helpers.ExifHelper.ApplyMetadata(stream, meta);
+                    stream = await Task.Run(() =>
+                    {
+                        var cropped = CropStreamToAspectRatio(inStream, ratio);
+                        return (System.IO.Stream)Helpers.ExifHelper.ApplyMetadata(cropped, meta);
+                    });
                 }
                 catch (Exception exifEx)
                 {
                     System.Diagnostics.Debug.WriteLine(
-                        $"[MainPageViewModel] ExifHelper.ApplyMetadata error: {exifEx.Message}");
+                        $"[MainPageViewModel] Crop/EXIF error: {exifEx.Message}");
                 }
 #endif
                 var (galleryPath, thumbPath) = await FileHelper.SavePhotoAsync(stream, city);
@@ -1775,7 +1809,10 @@ namespace TravelCamApp.ViewModels
             }
         }
 
-        private void ExecuteToggleMediaInfo()
+        // Guard: prevents double-tap from launching two concurrent reads
+        private bool _isLoadingMediaInfo;
+
+        private async void ExecuteToggleMediaInfo()
         {
             if (IsMediaInfoVisible)
             {
@@ -1783,29 +1820,95 @@ namespace TravelCamApp.ViewModels
                 return;
             }
 
+            if (_isLoadingMediaInfo) return;
+
             var path = CurrentImageItem;
             if (string.IsNullOrEmpty(path)) return;
 
-#if ANDROID
+            _isLoadingMediaInfo = true;
             try
             {
-                CurrentMediaInfo = Helpers.ExifHelper.ReadMetadata(path);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"[MainPageViewModel] ReadMetadata error: {ex.Message}");
+#if ANDROID
+                // ReadMetadata does disk I/O (ExifInterface) — run off the main thread
+                var info = await Task.Run(() => Helpers.ExifHelper.ReadMetadata(path));
+                CurrentMediaInfo = info;
+#else
                 CurrentMediaInfo = new Models.MediaInfo
                 {
                     FileName = System.IO.Path.GetFileName(path)
                 };
-            }
-#else
-            CurrentMediaInfo = new Models.MediaInfo
-            {
-                FileName = System.IO.Path.GetFileName(path)
-            };
 #endif
-            IsMediaInfoVisible = true;
+                IsMediaInfoVisible = true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[MainPageViewModel] ReadMetadata error: {ex.Message}");
+                CurrentMediaInfo = new Models.MediaInfo
+                {
+                    FileName = System.IO.Path.GetFileName(path)
+                };
+                IsMediaInfoVisible = true;
+            }
+            finally
+            {
+                _isLoadingMediaInfo = false;
+            }
+        }
+
+        /// <summary>
+        /// Reads EXIF metadata from <paramref name="filePath"/> and populates
+        /// <see cref="GalleryOverlayItems"/> with the values recorded at capture time.
+        /// Only items with non-empty values are included, matching the names used in the
+        /// live camera overlay (City, Country, Temperature, etc.).
+        /// </summary>
+        public async Task LoadGalleryOverlayItemsAsync(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                GalleryOverlayItems = new ObservableCollection<Models.OverlayItem>();
+                IsGalleryOverlayVisible = false;
+                return;
+            }
+
+#if ANDROID
+            Models.MediaInfo? info = null;
+            try
+            {
+                info = await Task.Run(() => Helpers.ExifHelper.ReadMetadata(filePath));
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[MainPageViewModel] LoadGalleryOverlayItemsAsync error: {ex.Message}");
+            }
+
+            var items = new List<Models.OverlayItem>();
+            if (info != null)
+            {
+                void Add(string name, string val)
+                {
+                    if (!string.IsNullOrWhiteSpace(val))
+                        items.Add(new Models.OverlayItem(name, val));
+                }
+
+                Add("City",        info.CityText);
+                Add("Country",     info.CountryText);
+                Add("Temperature", info.TemperatureText);
+                Add("Altitude",    info.AltitudeText);
+                Add("GPS",         info.GpsCoordsText);
+                Add("Heading",     info.HeadingText);
+                Add("Speed",       info.SpeedText);
+                Add("Date",        info.CaptureDateText);
+            }
+
+            GalleryOverlayItems = new ObservableCollection<Models.OverlayItem>(items);
+            IsGalleryOverlayVisible = CameraSettings.ShowSensorOverlay && items.Count > 0;
+#else
+            GalleryOverlayItems = new ObservableCollection<Models.OverlayItem>();
+            IsGalleryOverlayVisible = false;
+            await Task.CompletedTask;
+#endif
         }
 
         #endregion

--- a/Projects/TravelCam/TravelCamApp/Views/ImageViewerView.xaml
+++ b/Projects/TravelCam/TravelCamApp/Views/ImageViewerView.xaml
@@ -3,6 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:vm="clr-namespace:TravelCamApp.ViewModels"
+             xmlns:views="clr-namespace:TravelCamApp.Views"
+             xmlns:models="clr-namespace:TravelCamApp.Models"
              xmlns:converters="clr-namespace:TravelCamApp.Converters"
              xmlns:sys="clr-namespace:System;assembly=netstandard"
              xmlns:selectors="clr-namespace:TravelCamApp.Selectors"
@@ -117,7 +119,8 @@
             </Grid>
 
             <!-- ── Row 1: CarouselView + shared video player overlay ── -->
-            <Grid Grid.Row="1" BackgroundColor="Black">
+            <Grid x:Name="ImageAreaGrid" Grid.Row="1" BackgroundColor="Black"
+                  SizeChanged="OnImageAreaSizeChanged">
 
                 <CarouselView x:Name="MainCarousel"
                               ItemsSource="{Binding GalleryImagePaths}"
@@ -143,6 +146,7 @@
                                       BackgroundColor="Black"
                                       ShouldShowPlaybackControls="True"
                                       ShouldAutoPlay="False" />
+
             </Grid>
 
             <!-- ── Row 2: Thumbnail strip ── -->
@@ -203,6 +207,44 @@
                     </Border.GestureRecognizers>
                 </Border>
             </Grid>
+
+            <!-- ── Sensor data overlay pill (bottom-right of actual image) ── -->
+            <!-- Shows EXIF metadata from the current image — NOT live sensor data.
+                 Margin is set from code-behind (UpdateOverlayPosition) to compensate
+                 for AspectFit letterbox/pillarbox bars that vary per image.
+                 IsVisible driven by IsGalleryOverlayVisible (requires ShowSensorOverlay=true
+                 AND at least one item with data from the image EXIF). -->
+            <Border x:Name="SensorOverlayPill"
+                    Grid.Row="1"
+                    HorizontalOptions="End" VerticalOptions="End"
+                    Margin="0,0,12,12"
+                    BackgroundColor="#99000000"
+                    StrokeShape="RoundRectangle 10"
+                    Stroke="Transparent"
+                    Padding="10,10"
+                    IsVisible="{Binding IsGalleryOverlayVisible}">
+                <VerticalStackLayout Spacing="4"
+                                     HorizontalOptions="Start"
+                                     BindableLayout.ItemsSource="{Binding GalleryOverlayItems}">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="models:OverlayItem">
+                            <VerticalStackLayout Spacing="0" HorizontalOptions="Start">
+                                <Label Text="{Binding Name}"
+                                       FontSize="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DataOverlayViewModel.LabelFontSize}"
+                                       CharacterSpacing="0.6"
+                                       TextColor="#9E9E9E"
+                                       LineBreakMode="NoWrap"
+                                       TextTransform="Uppercase" />
+                                <Label Text="{Binding Value}"
+                                       FontSize="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DataOverlayViewModel.ValueFontSize}"
+                                       FontAttributes="Bold"
+                                       TextColor="#FFFFFF"
+                                       LineBreakMode="NoWrap" />
+                            </VerticalStackLayout>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+            </Border>
 
             <!-- ── Media Info Overlay (spans all rows) ── -->
             <!-- Dimmed backdrop — tap to close -->
@@ -405,6 +447,18 @@
                     </ScrollView>
                 </Border>
             </Grid>
+
+            <!-- ── Sensor settings overlay (spans all rows) ── -->
+            <!-- IsVisible is managed from code-behind (WireSensorSettings) to avoid
+                 BindingContext conflict: this element's BindingContext is set to
+                 OverlaySettingsViewModel at runtime, so XAML bindings to
+                 MainPageViewModel properties won't resolve correctly. -->
+            <views:OverlaySettingsView
+                x:Name="SensorSettingsOverlay"
+                Grid.Row="0" Grid.RowSpan="4"
+                IsVisible="False"
+                HorizontalOptions="Fill" VerticalOptions="Fill"
+                InputTransparent="False" />
 
         </Grid>
     </ContentView.Content>

--- a/Projects/TravelCam/TravelCamApp/Views/ImageViewerView.xaml.cs
+++ b/Projects/TravelCam/TravelCamApp/Views/ImageViewerView.xaml.cs
@@ -10,7 +10,6 @@ namespace TravelCamApp.Views
 {
     public partial class ImageViewerView : ContentView
     {
-        private bool _isScrollingFromCarousel = false;
         private CancellationTokenSource? _scrollDebounceCancel;
         // Prevents re-entrant calls: setting CurrentImageIndex notifies CurrentImageItem,
         // which updates SelectedItem via binding, which fires SelectionChanged again.
@@ -20,11 +19,18 @@ namespace TravelCamApp.Views
         {
             InitializeComponent();
 
-            // Stop the shared video player automatically when the gallery is closed.
             PropertyChanged += (_, e) =>
             {
-                if (e.PropertyName == nameof(IsVisible) && !IsVisible)
+                if (e.PropertyName != nameof(IsVisible)) return;
+                if (!IsVisible)
+                {
                     StopSharedVideoPlayer();
+                }
+                else
+                {
+                    UpdateOverlayPosition();
+                    _ = LoadCurrentImageOverlayAsync();
+                }
             };
         }
 
@@ -65,35 +71,37 @@ namespace TravelCamApp.Views
 
         private async void OnCarouselPositionChanged(object? sender, EventArgs e)
         {
-            // Mark that scroll is happening from carousel (not user thumbnail tap)
-            _isScrollingFromCarousel = true;
-
-            // Debounce: cancel previous timer and start new one
+            // Debounce: cancel previous timer and start a new one.
             _scrollDebounceCancel?.Cancel();
             _scrollDebounceCancel = new CancellationTokenSource();
 
             try
             {
-                // Wait 50ms before scrolling to allow carousel animation to settle
                 await Task.Delay(50, _scrollDebounceCancel.Token);
 
-                // Scroll the thumbnail strip to keep it in sync (no animation to avoid conflict)
-                if (BindingContext is MainPageViewModel vm && MainCarousel != null && ThumbnailStrip != null && !_scrollDebounceCancel.Token.IsCancellationRequested)
+                // Debounce settled — sync thumbnail strip.
+                if (BindingContext is MainPageViewModel vm && MainCarousel != null && ThumbnailStrip != null)
                 {
                     var newIndex = MainCarousel.Position;
                     if (newIndex >= 0 && newIndex < vm.GalleryImagePaths.Count)
                         ThumbnailStrip.ScrollTo(newIndex, position: ScrollToPosition.Center, animate: false);
                 }
+
+                StopSharedVideoPlayer();
+
+                if (BindingContext is MainPageViewModel viewModel && viewModel.IsMediaInfoVisible)
+                    viewModel.IsMediaInfoVisible = false;
+
+                UpdateOverlayPosition();
+                await LoadCurrentImageOverlayAsync();
+            }
+            catch (OperationCanceledException)
+            {
+                // Debounce cancelled by a newer position change — expected, do nothing.
             }
             finally
             {
-                _isScrollingFromCarousel = false;
             }
-
-            // Hide shared video player and close info panel when swiping to another item
-            StopSharedVideoPlayer();
-            if (BindingContext is MainPageViewModel viewModel && viewModel.IsMediaInfoVisible)
-                viewModel.IsMediaInfoVisible = false;
         }
 
         private void OnInfoBackdropTapped(object? sender, TappedEventArgs e)
@@ -153,6 +161,158 @@ namespace TravelCamApp.Views
             }
 
             SharedVideoPlayer.IsVisible = false;
+        }
+
+        // ── Sensor overlay position ────────────────────────────────────────
+
+        private void OnImageAreaSizeChanged(object? sender, EventArgs e) => UpdateOverlayPosition();
+
+        /// <summary>
+        /// Asks the ViewModel to load EXIF overlay items for the currently displayed image.
+        /// Called on gallery open and after each swipe settles.
+        /// </summary>
+        private async Task LoadCurrentImageOverlayAsync()
+        {
+            if (BindingContext is not MainPageViewModel vm) return;
+            if (vm.GalleryImagePaths == null || vm.GalleryImagePaths.Count == 0) return;
+
+            var index = MainCarousel?.Position ?? 0;
+            if (index < 0 || index >= vm.GalleryImagePaths.Count) return;
+
+            await vm.LoadGalleryOverlayItemsAsync(vm.GalleryImagePaths[index]);
+        }
+
+        /// <summary>
+        /// Adjusts SensorOverlayPill's bottom/right margin so the pill sits at the
+        /// bottom-right corner of the DISPLAYED image, not the Row 1 container.
+        /// AspectFit centers the image with letterbox/pillarbox bars that vary per image,
+        /// so the margin must be computed per image.
+        ///
+        /// Image raw dimensions come from BitmapFactory header-only decode (no pixels loaded).
+        /// EXIF orientation is read to correct swapped W/H on rotated photos.
+        /// </summary>
+        private void UpdateOverlayPosition()
+        {
+            const double EdgePad = 12;
+
+            try
+            {
+                if (BindingContext is not MainPageViewModel vm) return;
+                if (vm.GalleryImagePaths == null || vm.GalleryImagePaths.Count == 0) return;
+
+                var index = MainCarousel?.Position ?? 0;
+                if (index < 0 || index >= vm.GalleryImagePaths.Count) return;
+
+                // Use ImageAreaGrid (the named Row-1 Grid) for reliable container dimensions.
+                double containerW = ImageAreaGrid.Width;
+                double containerH = ImageAreaGrid.Height;
+                if (containerW <= 0 || containerH <= 0) return;
+
+                double imageW = 0, imageH = 0;
+
+#if ANDROID
+                var filePath = vm.GalleryImagePaths[index];
+                if (File.Exists(filePath))
+                {
+                    // Header-only decode — reads just a few bytes, does not load pixels.
+                    var opts = new Android.Graphics.BitmapFactory.Options { InJustDecodeBounds = true };
+                    Android.Graphics.BitmapFactory.DecodeFile(filePath, opts);
+                    imageW = opts.OutWidth;
+                    imageH = opts.OutHeight;
+
+                    // BitmapFactory returns raw stored dimensions, ignoring EXIF orientation.
+                    // Correct for 90°/270° rotations so the aspect ratio reflects what is DISPLAYED.
+                    try
+                    {
+                        using var exif = new Android.Media.ExifInterface(filePath);
+                        int orientation = exif.GetAttributeInt(
+                            Android.Media.ExifInterface.TagOrientation,
+                            (int)Android.Media.Orientation.Normal);
+                        // Values 5–8 indicate a 90° or 270° rotation → swap W and H.
+                        if (orientation >= 5)
+                            (imageW, imageH) = (imageH, imageW);
+                    }
+                    catch { /* EXIF unreadable — use raw dimensions */ }
+                }
+#endif
+
+                if (imageW <= 0 || imageH <= 0)
+                {
+                    SensorOverlayPill.Margin = new Thickness(0, 0, EdgePad, EdgePad);
+                    return;
+                }
+
+                double containerAspect = containerW / containerH;
+                double imageAspect    = imageW / imageH;
+
+                double displayW, displayH;
+                if (containerAspect > imageAspect)
+                {
+                    // Pillarbox: image fits full height, black bars left and right.
+                    displayH = containerH;
+                    displayW = containerH * imageAspect;
+                }
+                else
+                {
+                    // Letterbox: image fits full width, black bars top and bottom.
+                    displayW = containerW;
+                    displayH = containerW / imageAspect;
+                }
+
+                double rightMargin  = (containerW - displayW) / 2.0 + EdgePad;
+                double bottomMargin = (containerH - displayH) / 2.0 + EdgePad;
+
+                SensorOverlayPill.Margin = new Thickness(0, 0, rightMargin, bottomMargin);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[ImageViewerView] UpdateOverlayPosition error: {ex.Message}");
+            }
+        }
+
+        // ── Sensor settings overlay ────────────────────────────────────────
+
+        /// <summary>
+        /// Called once from MainPage constructor to wire the shared OverlaySettingsViewModel
+        /// into this view's settings overlay.
+        /// IsVisible is driven from code (not XAML binding) because setting BindingContext
+        /// to OverlaySettingsViewModel would break any MainPageViewModel XAML bindings.
+        /// </summary>
+        public void WireSensorSettings(OverlaySettingsViewModel vm, MainPageViewModel mainVm)
+        {
+            SensorSettingsOverlay.BindingContext = vm;
+
+            // Drive IsVisible from code so it isn't affected by the BindingContext override.
+            mainVm.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName != nameof(MainPageViewModel.IsGallerySettingsVisible)) return;
+
+                SensorSettingsOverlay.IsVisible = mainVm.IsGallerySettingsVisible;
+                if (mainVm.IsGallerySettingsVisible)
+                {
+                    vm.LoadFromOverlayItems(mainVm.OverlayItems);
+                    vm.FontSize = mainVm.DataOverlayViewModel.FontSize;
+                }
+            };
+
+            SensorSettingsOverlay.CloseRequested += async (s, e) =>
+            {
+                try { await HideGallerySettingsAsync(vm, mainVm); }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine(
+                        $"[ImageViewerView] HideSettings error: {ex.Message}");
+                }
+            };
+        }
+
+        private async Task HideGallerySettingsAsync(OverlaySettingsViewModel vm, MainPageViewModel mainVm)
+        {
+            mainVm.DataOverlayViewModel.FontSize = vm.FontSize;
+            await vm.SaveSettingsAsync();
+            vm.ApplyToOverlayItems(mainVm.OverlayItems);
+            mainVm.DataOverlayViewModel.RefreshVisibleItems();
+            mainVm.IsGallerySettingsVisible = false;
         }
     }
 }

--- a/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml
+++ b/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml
@@ -364,6 +364,7 @@
 
         <!-- Image viewer overlay — full-screen, above all other overlays -->
         <views:ImageViewerView
+            x:Name="GalleryView"
             Grid.RowSpan="2"
             IsVisible="{Binding IsImageViewerVisible}"
             HorizontalOptions="Fill" VerticalOptions="Fill"

--- a/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml.cs
+++ b/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml.cs
@@ -34,6 +34,9 @@ namespace TravelCamApp.Views
             _sensorSettingsVm = sensorSettingsVm;
             _cameraSettingsVm = cameraSettingsVm;
 
+            // ── Gallery sensor settings overlay ──────────────────────────────
+            GalleryView.WireSensorSettings(_sensorSettingsVm, viewModel);
+
             // ── Sensor settings overlay ──────────────────────────────────────
             SensorSettingsOverlay.BindingContext = _sensorSettingsVm;
 
@@ -190,12 +193,12 @@ namespace TravelCamApp.Views
             try
             {
                 // ── Step 1: natural visible area (AspectFit of sensor resolution) ──────────
-                // Use the user-selected resolution if set; otherwise fall back to the highest
-                // available resolution (last entry in SupportedResolutions).
-                var selectedRes = _cameraSettingsVm.GetSelectedResolutionSize();
-                var res = selectedRes.HasValue
-                    ? selectedRes.Value
-                    : selectedCamera.SupportedResolutions[selectedCamera.SupportedResolutions.Count - 1];
+                // Always use the camera's native (largest) resolution for this calculation.
+                // The user-selected capture resolution only affects post-processing output —
+                // the live preview always streams the full sensor feed at its native aspect ratio.
+                var res = selectedCamera.SupportedResolutions
+                    .OrderByDescending(s => (long)s.Width * (long)s.Height)
+                    .First();
 
                 // Normalize to landscape-first so portrait/landscape reporting differences don't matter
                 double camLong  = Math.Max(res.Width, res.Height);


### PR DESCRIPTION
All heavy image cropping and EXIF read/write operations now run on a background thread using Task.Run to prevent UI freezes, especially on Android. Added a guard (_isLoadingMediaInfo) to prevent concurrent gallery info panel EXIF reads. Improved error handling and ensured fallback MediaInfo is shown on failure. This makes gallery and capture flows more robust and responsive.

Always use native resolution for live preview calculation

Updated logic to always use the camera's largest (native) resolution when determining the live preview's visible area. The user-selected capture resolution now only affects post-processing output, ensuring the preview always streams the full sensor feed at its native aspect ratio.

Add gallery sensor overlay & settings panel to ImageViewer

- Introduced IsGallerySettingsVisible to control a new sensor settings overlay for the gallery.
- OpenSettingsCommand now opens the gallery overlay when viewing images.
- Added DataOverlayView (sensor pill) to ImageViewerView, with dynamic margin calculation to align with the displayed image corner, accounting for aspect ratio and EXIF orientation.
- Added OverlaySettingsView for gallery sensor settings, with code-driven visibility and data sync.
- Wired up gallery overlay to shared OverlaySettingsViewModel in MainPage.
- Improved event handling and code comments for overlay positioning and carousel sync.

Add EXIF overlay pill to gallery image viewer

Display an overlay pill with EXIF metadata for each image in the gallery, matching the style and fields of the live camera sensor overlay. The overlay is populated from image EXIF data (Android only) and shown when enabled in settings and data is available. Replaces the live sensor overlay in gallery view. Overlay updates on image swipe and is positioned to align with the displayed image.