### PR TITLE
== VERY STABLE VERSION ==

### DIFF
--- a/Projects/TravelCam/TravelCamApp/Helpers/SettingsHelper.cs
+++ b/Projects/TravelCam/TravelCamApp/Helpers/SettingsHelper.cs
@@ -134,6 +134,92 @@ namespace TravelCamApp.Helpers
             }
         }
 
+        // ── Cached sensor data API ────────────────────────────────────────────
+        private const string PrefCachedSensorData = "CachedSensorData";
+
+        /// <summary>
+        /// Saves the last known sensor values to SharedPreferences so they can be
+        /// displayed immediately on the next app launch, before the first sensor tick.
+        /// Thread-safe: Android SharedPreferences is thread-safe.
+        /// Called on every sensor update and on app stop/destroy.
+        /// </summary>
+        public static void SaveCachedSensorData(Models.SensorData data)
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(data, JsonOptions);
+                Preferences.Set(PrefCachedSensorData, json);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[SettingsHelper] SaveCachedSensorData error: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Loads the last known sensor values from SharedPreferences.
+        /// Returns null on first launch (no cached data yet).
+        /// </summary>
+        public static Models.SensorData? LoadCachedSensorData()
+        {
+            try
+            {
+                var json = Preferences.Get(PrefCachedSensorData, string.Empty);
+                if (string.IsNullOrEmpty(json))
+                    return null;
+                return JsonSerializer.Deserialize<Models.SensorData>(json, JsonOptions);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[SettingsHelper] LoadCachedSensorData error: {ex.Message}");
+                return null;
+            }
+        }
+
+        // ── Camera layout cache API ───────────────────────────────────────────
+        private const string PrefCameraLayout = "CameraLayout";
+
+        /// <summary>
+        /// Saves the computed camera layout to SharedPreferences so it can be
+        /// applied immediately on the next app launch, before the first render.
+        /// Called synchronously from ApplyCameraLayout — SharedPreferences is non-blocking.
+        /// </summary>
+        public static void SaveCameraLayout(CameraLayoutCache cache)
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(cache, JsonOptions);
+                Preferences.Set(PrefCameraLayout, json);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[SettingsHelper] SaveCameraLayout error: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Loads the last computed camera layout from SharedPreferences.
+        /// Returns null on first launch (no cache yet).
+        /// </summary>
+        public static CameraLayoutCache? LoadCameraLayout()
+        {
+            try
+            {
+                var json = Preferences.Get(PrefCameraLayout, string.Empty);
+                if (string.IsNullOrEmpty(json)) return null;
+                return JsonSerializer.Deserialize<CameraLayoutCache>(json, JsonOptions);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[SettingsHelper] LoadCameraLayout error: {ex.Message}");
+                return null;
+            }
+        }
+
         // ── Private serialization record ──────────────────────────────────────
         // Used only for JSON within the OverlayItemsJson preference string.
         private sealed class OverlayItemRecord
@@ -157,5 +243,42 @@ namespace TravelCamApp.Helpers
     {
         public string? Name { get; set; }
         public bool IsVisible { get; set; }
+    }
+
+    /// <summary>
+    /// Cached output of ApplyCameraLayout — all values needed to restore the
+    /// container and crop bars to their last correct position without recomputing.
+    /// </summary>
+    public class CameraLayoutCache
+    {
+        // Input dimensions — used to detect orientation changes between sessions.
+        public double CameraViewWidth  { get; set; }
+        public double CameraViewHeight { get; set; }
+
+        // CameraViewChildrenContainer
+        public double ContainerLeft   { get; set; }
+        public double ContainerTop    { get; set; }
+        public double ContainerWidth  { get; set; }
+        public double ContainerHeight { get; set; }
+
+        // Letterbox bars (top / bottom)
+        public double TopBarTop     { get; set; }
+        public double TopBarHeight  { get; set; }
+        public bool   TopBarVisible { get; set; }
+        public double BottomBarTop     { get; set; }
+        public double BottomBarHeight  { get; set; }
+        public bool   BottomBarVisible { get; set; }
+
+        // Pillarbox bars (left / right)
+        public double LeftBarLeft    { get; set; }
+        public double LeftBarTop     { get; set; }
+        public double LeftBarWidth   { get; set; }
+        public double LeftBarHeight  { get; set; }
+        public bool   LeftBarVisible { get; set; }
+        public double RightBarRight  { get; set; }
+        public double RightBarTop    { get; set; }
+        public double RightBarWidth  { get; set; }
+        public double RightBarHeight { get; set; }
+        public bool   RightBarVisible { get; set; }
     }
 }

--- a/Projects/TravelCam/TravelCamApp/ViewModels/DataOverlayViewModel.cs
+++ b/Projects/TravelCam/TravelCamApp/ViewModels/DataOverlayViewModel.cs
@@ -113,6 +113,16 @@ namespace TravelCamApp.ViewModels
         }
 
         /// <summary>
+        /// Saves the current sensor values to SharedPreferences as a cache.
+        /// Safe to call from any thread. Called by MainPageViewModel on app stop/destroy.
+        /// </summary>
+        public void SaveCurrentSensorData()
+        {
+            if (_lastSensorData == null) return;
+            SettingsHelper.SaveCachedSensorData(_lastSensorData);
+        }
+
+        /// <summary>
         /// Loads saved sensor visibility settings from persistent storage.
         /// Call once during app initialization.
         /// </summary>
@@ -140,6 +150,12 @@ namespace TravelCamApp.ViewModels
 
                 // Rebuild VisibleOverlayItems in the current (possibly reordered) sequence.
                 RefreshVisibleItems();
+
+                // Load cached sensor values so the overlay shows last-known data immediately,
+                // instead of blanks while waiting for the first 10-second sensor tick.
+                var cached = SettingsHelper.LoadCachedSensorData();
+                if (cached != null)
+                    ApplyCachedSensorData(cached);
             }
             catch (Exception ex)
             {
@@ -174,6 +190,10 @@ namespace TravelCamApp.ViewModels
             // Capture snapshot before dispatching to UI thread
             _lastSensorData = data;
 
+            // Persist every update so cached values are always fresh.
+            // Preferences.Set is thread-safe; this runs on the SensorHelper background thread.
+            SettingsHelper.SaveCachedSensorData(data);
+
             Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
             {
                 if (_isDisposed) return;
@@ -190,6 +210,37 @@ namespace TravelCamApp.ViewModels
                     data.Longitude.ToString(CultureInfo.InvariantCulture));
                 UpdateItem("Date", data.Timestamp.ToString("MM/dd/yyyy"));
                 UpdateItem("Time", data.Timestamp.ToString("HH:mm:ss"));
+                UpdateItem("Heading",
+                    data.Heading.HasValue ? $"{data.Heading.Value:F0}\u00b0" : "N/A");
+                UpdateItem("Speed",
+                    data.Speed.HasValue ? $"{data.Speed.Value * 3.6:F1} km/h" : "N/A");
+            });
+        }
+
+        /// <summary>
+        /// Populates overlay items from cached sensor data for instant display on startup.
+        /// Uses DateTime.Now for Date/Time since cached timestamps are stale.
+        /// Must be called on the main thread (or will dispatch internally).
+        /// </summary>
+        private void ApplyCachedSensorData(Models.SensorData data)
+        {
+            Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
+            {
+                if (_isDisposed) return;
+
+                UpdateItem("Temperature",
+                    data.Temperature.HasValue ? $"{data.Temperature.Value:F1}\u00b0C" : "N/A");
+                UpdateItem("City", data.City ?? "Unknown");
+                UpdateItem("Country", data.Country ?? "Unknown");
+                UpdateItem("Altitude",
+                    data.Altitude.HasValue ? $"{data.Altitude.Value:F0}m" : "N/A");
+                UpdateItem("Latitude",
+                    data.Latitude.ToString(CultureInfo.InvariantCulture));
+                UpdateItem("Longitude",
+                    data.Longitude.ToString(CultureInfo.InvariantCulture));
+                // Use current date/time — cached timestamp is from a previous session.
+                UpdateItem("Date", DateTime.Now.ToString("MM/dd/yyyy"));
+                UpdateItem("Time", DateTime.Now.ToString("HH:mm:ss"));
                 UpdateItem("Heading",
                     data.Heading.HasValue ? $"{data.Heading.Value:F0}\u00b0" : "N/A");
                 UpdateItem("Speed",

--- a/Projects/TravelCam/TravelCamApp/ViewModels/MainPageViewModel.cs
+++ b/Projects/TravelCam/TravelCamApp/ViewModels/MainPageViewModel.cs
@@ -675,6 +675,9 @@ namespace TravelCamApp.ViewModels
             // already stopped the camera and cleaned up state.
             if (_isDestroyed) return;
 
+            // Safety-net save: sensors stop next — persist current values now.
+            _sensorValueViewModel.SaveCurrentSensorData();
+
             _sensorHelper.Stop();
 
             // Capture _cameraView before any await; OnWindowDestroying may null it concurrently.
@@ -754,6 +757,9 @@ namespace TravelCamApp.ViewModels
             }
 
             _windowSubscribed = false;
+
+            // Persist current sensor values before stopping — safety net for crash/force-close.
+            _sensorValueViewModel.SaveCurrentSensorData();
 
             // Stop sensors and camera view.
             _sensorHelper.Stop();

--- a/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml.cs
+++ b/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml.cs
@@ -12,6 +12,7 @@
 
 using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Views;
+using TravelCamApp.Helpers;
 using TravelCamApp.ViewModels;
 
 namespace TravelCamApp.Views
@@ -29,6 +30,12 @@ namespace TravelCamApp.Views
             CameraSettingsViewModel cameraSettingsVm)
         {
             InitializeComponent();
+
+            // Apply cached layout immediately — before BindingContext is set and before
+            // the first layout pass fires. Prevents overlay/rule-of-thirds appearing small
+            // in the center while waiting for the camera to initialize (~500-2000ms).
+            ApplyCachedLayout();
+
             BindingContext = viewModel;
 
             _sensorSettingsVm = sensorSettingsVm;
@@ -146,6 +153,52 @@ namespace TravelCamApp.Views
             // also fire PropertyChanged→ScheduleLayoutUpdate, so debouncing avoids double work.
             _lastAppliedW = 0;
             ScheduleLayoutUpdate();
+        }
+
+        // ── Camera layout cache ────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Restores the last computed camera layout from SharedPreferences.
+        /// Called in the constructor (before first layout pass) so elements have
+        /// the correct size and position from the very first render — no flash.
+        /// Safe to call even if no cache exists yet (returns silently on null).
+        /// </summary>
+        private void ApplyCachedLayout()
+        {
+            try
+            {
+                var c = SettingsHelper.LoadCameraLayout();
+                if (c == null) return;
+
+                CameraViewChildrenContainer.Margin      = new Thickness(c.ContainerLeft, c.ContainerTop, 0, 0);
+                CameraViewChildrenContainer.WidthRequest  = c.ContainerWidth;
+                CameraViewChildrenContainer.HeightRequest = c.ContainerHeight;
+
+                CropTopBar.Margin       = new Thickness(0, c.TopBarTop, 0, 0);
+                CropTopBar.HeightRequest = c.TopBarHeight;
+                CropTopBar.IsVisible    = c.TopBarVisible;
+
+                CropBottomBar.Margin       = new Thickness(0, c.BottomBarTop, 0, 0);
+                CropBottomBar.HeightRequest = c.BottomBarHeight;
+                CropBottomBar.IsVisible    = c.BottomBarVisible;
+
+                CropLeftBar.Margin       = new Thickness(c.LeftBarLeft, c.LeftBarTop, 0, 0);
+                CropLeftBar.WidthRequest  = c.LeftBarWidth;
+                CropLeftBar.HeightRequest = c.LeftBarHeight;
+                CropLeftBar.IsVisible    = c.LeftBarVisible;
+
+                CropRightBar.Margin       = new Thickness(0, c.RightBarTop, c.RightBarRight, 0);
+                CropRightBar.WidthRequest  = c.RightBarWidth;
+                CropRightBar.HeightRequest = c.RightBarHeight;
+                CropRightBar.IsVisible    = c.RightBarVisible;
+
+                System.Diagnostics.Debug.WriteLine(
+                    $"[MainPage] Cached layout applied: container {c.ContainerWidth:F0}×{c.ContainerHeight:F0} at ({c.ContainerLeft:F0},{c.ContainerTop:F0})");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[MainPage] ApplyCachedLayout error: {ex.Message}");
+            }
         }
 
         // ── Camera view alignment ──────────────────────────────────────────────────
@@ -314,6 +367,34 @@ namespace TravelCamApp.Views
                 CropRightBar.WidthRequest  = sideBarW;
                 CropRightBar.HeightRequest = naturalH;
                 CropRightBar.IsVisible = sideBarW > 0.5;
+
+                // ── Step 5: persist layout for instant restore on next start ─────────────
+                // SharedPreferences.apply() is non-blocking — safe to call on the main thread.
+                SettingsHelper.SaveCameraLayout(new CameraLayoutCache
+                {
+                    CameraViewWidth  = cameraViewWidth,
+                    CameraViewHeight = cameraViewHeight,
+                    ContainerLeft    = feedOffsetX + sideBarW,
+                    ContainerTop     = feedOffsetY + topBarH,
+                    ContainerWidth   = croppedW,
+                    ContainerHeight  = croppedH,
+                    TopBarTop        = feedOffsetY,
+                    TopBarHeight     = topBarH,
+                    TopBarVisible    = topBarH > 0.5,
+                    BottomBarTop     = feedOffsetY + topBarH + croppedH,
+                    BottomBarHeight  = topBarH,
+                    BottomBarVisible = topBarH > 0.5,
+                    LeftBarLeft      = feedOffsetX,
+                    LeftBarTop       = feedOffsetY,
+                    LeftBarWidth     = sideBarW,
+                    LeftBarHeight    = naturalH,
+                    LeftBarVisible   = sideBarW > 0.5,
+                    RightBarRight    = feedOffsetX,
+                    RightBarTop      = feedOffsetY,
+                    RightBarWidth    = sideBarW,
+                    RightBarHeight   = naturalH,
+                    RightBarVisible  = sideBarW > 0.5,
+                });
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Restore sensor and camera layout instantly on startup

Add persistent caches for last sensor data and camera layout using SharedPreferences. On app launch, restore overlays and camera UI to their last known state before hardware initialization completes, eliminating initial blank or jumping UI. Improves perceived responsiveness and startup polish.