### PR TITLE
Defer clock timer start; optimize shutter flash layout

### DIFF
--- a/Projects/TravelCam/TravelCamApp/ViewModels/DataOverlayViewModel.cs
+++ b/Projects/TravelCam/TravelCamApp/ViewModels/DataOverlayViewModel.cs
@@ -94,17 +94,28 @@ namespace TravelCamApp.ViewModels
             InitializeOverlayItems();
             _sensorHelper.SensorDataUpdated += OnSensorDataUpdated;
 
-            // 1-second timer keeps Date and Time items current independently of the
-            // 10-second sensor tick. Elapsed fires on a ThreadPool thread — dispatch to UI.
+            // Clock timer is created but NOT started in the constructor.
+            // StartClockTimer() is called after app initialization completes
+            // to avoid competing with layout/camera/permission work at startup.
             _clockTimer = new System.Timers.Timer(1000);
             _clockTimer.Elapsed += OnClockTick;
             _clockTimer.AutoReset = true;
-            _clockTimer.Start();
         }
 
         #endregion
 
         #region Public API
+
+        /// <summary>
+        /// Starts the 1-second clock timer that keeps Date/Time overlay items current.
+        /// Call once after app initialization completes (not during startup).
+        /// </summary>
+        public void StartClockTimer()
+        {
+            if (_isDisposed || _clockTimer == null) return;
+            if (_clockTimer.Enabled) return; // already running
+            _clockTimer.Start();
+        }
 
         /// <summary>
         /// Rebuilds VisibleOverlayItems from OverlayItems in their current order.

--- a/Projects/TravelCam/TravelCamApp/ViewModels/MainPageViewModel.cs
+++ b/Projects/TravelCam/TravelCamApp/ViewModels/MainPageViewModel.cs
@@ -448,6 +448,11 @@ namespace TravelCamApp.ViewModels
 
             // Mark app as successfully initialized — required for proper Activity recreation recovery
             _isAppInitialized = true;
+
+            // Start the 1-second clock timer now that initialization is done.
+            // Running it earlier competes with layout/camera/permission work on the main thread.
+            _sensorValueViewModel.StartClockTimer();
+
             System.Diagnostics.Debug.WriteLine("[MainPageViewModel] App fully initialized successfully");
 
             // If the camera view is already ready (OnAppearing → OnViewReady → waiting for init),

--- a/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml
+++ b/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml
@@ -196,10 +196,12 @@
             </HorizontalStackLayout>
 
             <!-- ── Shutter flash feedback — white overlay, fades on photo capture ──
-                 Always rendered (Opacity=0) so FadeTo starts instantly with no IsVisible delay. -->
+                 Hidden by default so it doesn't participate in layout passes at startup.
+                 Made visible and animated in PlayShutterFlashAsync, then hidden again. -->
             <BoxView x:Name="ShutterFlash"
                      BackgroundColor="White"
                      Opacity="0"
+                     IsVisible="False"
                      InputTransparent="True"
                      HorizontalOptions="Fill"
                      VerticalOptions="Fill" />

--- a/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml.cs
+++ b/Projects/TravelCam/TravelCamApp/Views/MainPage.xaml.cs
@@ -442,8 +442,10 @@ namespace TravelCamApp.Views
         {
             try
             {
+                ShutterFlash.IsVisible = true;
                 ShutterFlash.Opacity = 1.0;
                 await ShutterFlash.FadeToAsync(0, 200, Easing.CubicOut);
+                ShutterFlash.IsVisible = false;
             }
             catch { /* page may be tearing down — ignore */ }
         }


### PR DESCRIPTION
Improves startup by starting the overlay clock timer only after app initialization, not in the ViewModel constructor. ShutterFlash BoxView is now hidden by default to reduce initial layout work; its visibility is managed explicitly during the flash animation. These changes enhance app launch performance and UI responsiveness.